### PR TITLE
Autoload the call to org-cite-register-processor

### DIFF
--- a/citar-org.el
+++ b/citar-org.el
@@ -27,10 +27,15 @@
 ;;
 ;;; Commentary:
 ;;
-;;  This is a small package that intergrates citar and org-cite.  It
-;;  provides a simple org-cite processor with "follow" and "insert" capabilties.
+;;  This is a small package that integrates citar and org-cite.  It
+;;  provides a simple org-cite processor with "follow", "insert", and
+;;  "activate" capabilities.
 ;;
-;;  Simply load this file and it will configure them for 'org-cite.'
+;;  Simply load this file (or its generated autoloads) and it will
+;;  make the processor available to 'org-cite'.  To instruct org-cite
+;;  to use citar, set one or more of the customization variables
+;;  'org-cite-activate-processor', 'org-cite-follow-processor', and
+;;  'org-cite-insert-processor' to the symbol 'citar.
 ;;
 ;;; Code:
 
@@ -348,12 +353,14 @@ Argument CITATION is an org-element holding the references."
   (dolist (activate-func citar-org-activation-functions)
     (funcall activate-func citation)))
 
-(org-cite-register-processor 'citar
-  :insert (org-cite-make-insert-processor
-           #'citar-org-insert
-           #'citar-org-select-style)
-  :follow #'citar-org-follow
-  :activate #'citar-org-activate)
+;;;###autoload
+(with-eval-after-load 'oc
+  (org-cite-register-processor 'citar
+    :insert (org-cite-make-insert-processor
+             #'citar-org-insert
+             #'citar-org-select-style)
+    :follow #'citar-org-follow
+    :activate #'citar-org-activate))
 
 (provide 'citar-org)
 ;;; citar-org.el ends here


### PR DESCRIPTION
Since all the required functions are now autoloaded (#342), we can also autoload the call to `org-cite-register-processor` (protected by `with-eval-after-load 'oc`). This will register the `citar` processor whenever org-cite is loaded, but will not load `citar-org` until:
* the `org-cite-{activate,follow,insert}-processor` variables have been set to `'citar`, and
* an Org-mode file is loaded and org-cite is activated, a citation is followed, or `org-cite-insert` is called.

The usage instructions are then simply "install citar" and "set the `org-cite-*-processor` variables to `'citar`". There is no need to arrange for `citar-org` to be loaded explicitly, which can pull in all of Org Mode if done too early, or can result in the org-cite processor not being registered if done too late. 