### PR TITLE
fix: normalize bibliography file paths where needed

### DIFF
--- a/citar-filenotify.el
+++ b/citar-filenotify.el
@@ -81,10 +81,11 @@ CHANGE refers to the notify argument."
   (pcase (cadr change)
     ('(nil changed) (funcall func scope))
     ('(created deleted renamed)
-     (if (member (nth 2 change)
-                 (seq-concatenate 'list
-                                  citar-bibliography
-                                  (citar--local-files-to-cache)))
+     (if (member
+          (nth 2 change)
+          (seq-concatenate 'list
+                           (citar-file--normalize-paths citar-bibliography)
+                           (citar--local-files-to-cache)))
          (citar-filenotify-refresh scope)
        (funcall func scope)))))
 

--- a/citar.el
+++ b/citar.el
@@ -78,22 +78,19 @@
   "Face used to highlight content in `citar' candidates."
   :group 'citar)
 
-(defcustom citar-bibliography
-  (citar-file--normalize-paths bibtex-completion-bibliography)
+(defcustom citar-bibliography bibtex-completion-bibliography
   "A list of bibliography files."
   ;; The bibtex-completion default is likely to be removed in the future.
   :group 'citar
   :type '(repeat file))
 
-(defcustom citar-library-paths
-  (citar-file--normalize-paths bibtex-completion-library-path)
+(defcustom citar-library-paths bibtex-completion-library-path
   "A list of files paths for related PDFs, etc."
   ;; The bibtex-completion default is likely to be removed in the future.
   :group 'citar
   :type '(repeat path))
 
-(defcustom citar-notes-paths
-  (citar-file--normalize-paths bibtex-completion-notes-path)
+(defcustom citar-notes-paths bibtex-completion-notes-path
   "A list of file paths for bibliographic notes."
   ;; The bibtex-completion default is likely to be removed in the future.
   :group 'citar
@@ -280,10 +277,10 @@ offering the selection candidates."
 (defun citar--local-files-to-cache ()
   "The local bibliographic files not included in the global bibliography."
   ;; We cache these locally to the buffer.
-  (let* ((local-bib-files
-          (citar-file--normalize-paths
-           (bibtex-completion-find-local-bibliography))))
-    (seq-difference local-bib-files citar-bibliography)))
+  (seq-difference (citar-file--normalize-paths
+                   (bibtex-completion-find-local-bibliography))
+                  (citar-file--normalize-paths
+                   citar-bibliography)))
 
 (defun citar-get-value (field item)
   "Return the FIELD value for ITEM."
@@ -471,7 +468,7 @@ are refreshed."
   (unless (eq 'local scope)
     (setq citar--candidates-cache
       (citar--format-candidates
-       citar-bibliography)))
+        (citar-file--normalize-paths citar-bibliography))))
   (unless (eq 'global scope)
     (setq citar--local-candidates-cache
           (citar--format-candidates
@@ -657,7 +654,7 @@ With prefix, rebuild the cache before offering candidates."
 With prefix, rebuild the cache before offering candidates."
   (interactive (list (citar-select-refs
                       :rebuild-cache current-prefix-arg)))
-  (when (and (equal citar-notes-paths nil)
+  (when (and (null citar-notes-paths)
              (equal citar-file-open-note-function
                     'citar-file-open-notes-default-org))
     (message "You must set 'citar-notes-paths' to open notes with default notes function"))


### PR DESCRIPTION
We can't rely on the calls to `citar-file--normalize-paths` in the default values for the `citar-bibliography` defcustom, since those will be overridden by the user. Instead, normalize the paths where needed in the code.

The same applies to the defcustoms for `citar-{library,notes}-paths`; these are always used in contexts where no normalization is needed.

Fixes #351

PS: This bug is also fixed in @aikrahguzar's [branch](https://github.com/aikrahguzar/bibtex-actions/blob/ecb3df00ff3e9c68d5f41771b0587865f200ad9c/bibtex-actions.el#L316).