### PR TITLE
Autoload keymaps required for embark and simplify readme

### DIFF
--- a/README.org
+++ b/README.org
@@ -58,73 +58,57 @@ In addition, the following packages are strongly recommended for the best experi
 This is the minimal configuration, and will work with any completing-read compliant vertical completion UI, like Vertico, Selectrum, or the built-in icomplete-vertical, with actions available via =M-x= commands.
 
 #+BEGIN_SRC emacs-lisp
-(use-package bibtex-completion)
-
 (use-package citar
   :bind (("C-c b" . citar-insert-citation)
          :map minibuffer-local-map
          ("M-b" . citar-insert-preset))
-  :after (bibtex-completion)
-  :config
-  (setq citar-bibliography '("~/bib/references.bib"))
+  :custom
+  (citar-bibliography '("~/bib/references.bib"))
 #+END_SRC
 
 Since most of the command logic resides in bibtex-completion, that is where to look for different [[https://github.com/tmalsburg/helm-bibtex#basic-configuration-recommended][configuration options]].
 
 *** Embark
 
-Highly recommended, this option adds embark, for contextual access to actions in the minibuffer and at-point.
+Citar will automatically integrate with Embark if it is installed, offering contextual access to actions in the
+minibuffer and at-point.  Some citation commands prompt for multiple citation keys, for which Consult offers an enhanced
+interface:
 
 #+BEGIN_SRC emacs-lisp
-(use-package citar
-  :bind (("C-c b" . citar-insert-citation)
-         :map minibuffer-local-map
-         ("M-b" . citar-insert-preset))
-  :after (embark bibtex-completion)
-  :config
-  ;; Make the 'citar' bindings and targets available to `embark'.
-  (add-to-list 'embark-target-finders 'citar-citation-key-at-point)
-  (add-to-list 'embark-keymap-alist '(bib-reference . citar-map))
-  (add-to-list 'embark-keymap-alist '(citation-key . citar-buffer-map))
-  (setq citar-bibliography '("~/bib/references.bib"))
-
 ;; use consult-completing-read for enhanced interface
 (advice-add #'completing-read-multiple :override #'consult-completing-read-multiple)
 #+END_SRC
 
-When using this option, these actions are generic, and work the same across org, markdown, and latex modes.
+When using Embark, the Citar actions are generic, and work the same across org, markdown, and latex modes.
 
 *** Org-Cite
 
 #+CAPTION: org-cite at-point integration with =embark-act=
 [[file:images/org-cite-embark-point.png]]
 
-If you use org-mode, this is the best option.
-It includes the embark functionality above, but customizes menus and user-experience for org-cite.
-In other supported modes, it will work the same as the embark option above.
+If you use Org-Mode, this is the best option.  Use the basic configuration above, and /in addition/, configure Org-Cite
+to use Citar:
 
 #+BEGIN_SRC emacs-lisp
 ;; Set bibliography paths so they are the same.
 (defvar my/bibs '("~/bib/references.bib"))
 
 (use-package citar-org
-  :bind (("C-c b" . org-cite-insert)
-         ("M-o" . org-open-at-point)
-         :map minibuffer-local-map
-         ("M-b" . citar-insert-preset))
-  :after (embark oc)
-  :config
-  (setq citar-bibliography my/bibs
-        org-cite-global-bibliography my/bibs
-        org-cite-insert-processor 'citar
-        org-cite-follow-processor 'citar
-        org-cite-activate-processor 'citar))
-
-;; Use consult-completing-read for enhanced interface.
-(advice-add #'completing-read-multiple :override #'consult-completing-read-multiple)
+  :no-require
+  :bind ; optional
+  (:map org-mode-map
+        ("C-c b" . #'org-cite-insert)) ; Also bound to C-c C-x C-@
+  :custom
+  (org-cite-global-bibliography my/bibs)
+  (org-cite-insert-processor 'citar)
+  (org-cite-follow-processor 'citar)
+  (org-cite-activate-processor 'citar))
 #+END_SRC
 
-If you prefer to have the embark menu open with =org-open-at-point=, you should set this variable.
+You can insert citations with the =org-cite-insert= command, which is bound to =C-c C-x C-@= in Org-Mode buffers.  The
+optional ~:bind~ command above also gives it the shorter =C-c b= binding.
+
+If you prefer to have the Embark menu open with =org-open-at-point=, you should set this variable.
 
 #+BEGIN_SRC emacs-lisp
 (setq citar-at-point-function 'embark-act)

--- a/citar.el
+++ b/citar.el
@@ -180,6 +180,7 @@ and nil means no action."
 
 ;;; Keymaps
 
+;;;###autoload
 (defcustom citar-map
   (let ((map (make-sparse-keymap)))
     (define-key map (kbd "t") '("add pdf attachment" . citar-add-pdf-attachment))
@@ -202,6 +203,7 @@ and nil means no action."
   :group 'oc-citar
   :type '(restricted-sexp :match-alternatives (keymapp)))
 
+;;;###autoload
 (defcustom citar-buffer-map
   (let ((map (make-sparse-keymap)))
     (define-key map (kbd "o") '("open source document" . citar-open))
@@ -589,6 +591,7 @@ FORMAT-STRING."
 
 ;;; Embark
 
+;;;###autoload
 (defun citar-citation-key-at-point ()
   "Return citation keys at point as a list for `embark'."
   (when-let ((keys (or (citar-get-key-org-cite)
@@ -598,6 +601,12 @@ FORMAT-STRING."
 (defun citar--stringify-keys (keys)
   "Return a list of KEYS as a crm-string for `embark'."
   (if (listp keys) (string-join keys " & ") keys))
+
+;;;###autoload
+(with-eval-after-load 'embark
+  (add-to-list 'embark-target-finders 'citar-citation-key-at-point)
+  (add-to-list 'embark-keymap-alist '(bib-reference . citar-map))
+  (add-to-list 'embark-keymap-alist '(citation-key . citar-buffer-map)))
 
 ;;; Commands
 
@@ -753,6 +762,7 @@ With prefix, rebuild the cache before offering candidates."
    (citar--extract-keys
     keys-entries)))
 
+;;;###autoload
 (defun citar-run-default-action (keys)
   "Run the default action `citar-default-action' on KEYS."
   (let* ((keys-parsed


### PR DESCRIPTION
Set up the Embark integration automatically when Citar is loaded, and also add it to the autoload file. This means that Embark and Citar can be loaded in any order, and neither will pull in the other. Citar will be loaded the first time its target finder is invoked by `embark-act`.

There seems to be some redundancy between the embark action maps for `citar` and `citar-org`. Currently, loading `citar-org` overrides the action map for `bib-reference` targets, from `citar-map` to `citar-buffer-map`. This is of course, not ideal, and perhaps both of these action maps should be merged.

This PR also includes the simplified use-package stanza for `citar-org` made possible by #353, allowing its loading to be deferred to the last possible moment (fixes #340).