### PR TITLE
add citar-latex, citar-markdown

### DIFF
--- a/README.org
+++ b/README.org
@@ -116,10 +116,29 @@ If you prefer to have the Embark menu open with =org-open-at-point=, you should 
 
 You can invoke both =embark-act= and =embark-dwim=, however, independently of =org-at-point=, and in other modes such as =latex-mode=.
 
+*** Major-mode adapters
+:PROPERTIES:
+:CUSTOM_ID: major-mode-adapters
+:END:
+
+Citar includes an adapter framework to enable major-mode specific editing integration.
+Such adapters can provide the following capabilities, which one can configure with the ~citar-major-mode-functions~ alist:
+
+1. ~insert-keys~: to insert citation keys (this may go away though)
+2. ~insert-citation~: to insert citations
+3. ~local-bib-files~: to find bibliographic files associated with a buffer
+4. ~keys-at-point~: returns a list of citekeys at point
+
+Citar currently includes the following such adapters:
+
+1. ~citar-org~: by default, only supports ~org-cite~, but can one can configure for other formats
+2. ~citar-latex~: configurable bibtex, natbib and biblatex support
+3. ~citar-markdown~: by default, only supports the ~pandoc~ citation syntax
+
 ** Rich UI
-    :PROPERTIES:
-    :CUSTOM_ID: rich-ui
-    :END:
+:PROPERTIES:
+:CUSTOM_ID: rich-ui
+:END:
 
 There are three sections of the browsing UI.
 

--- a/citar-file.el
+++ b/citar-file.el
@@ -20,7 +20,6 @@
 (eval-when-compile
   (require 'cl-lib))
 (require 'seq)
-(require 'org-id)
 
 (declare-function citar-get-entry "citar")
 (declare-function citar-get-value "citar")
@@ -57,12 +56,6 @@ If you use 'org-roam' and 'org-roam-bibtex', you can use
 'orb-citar-edit-note' for this value."
   :group 'citar
   :type '(function))
-
-(defcustom citar-file-note-org-include nil
-  "The org note type."
-  :group 'citar
-  :type '(repeat (const :tag "Org ID" 'org-id)
-                 (const :tag "Org-Roam :ROAM_REF:" 'org-roam-ref)))
 
 (defcustom citar-file-parser-functions
   '(citar-file-parser-default)
@@ -177,36 +170,6 @@ Example: ':/path/to/test.pdf:PDF'."
                     (_ "xdg-open"))
                   nil 0 nil
                   file)))
-
-(defun citar-file-open-notes-default-org (key entry)
-  "Open a note file from KEY and ENTRY."
-  (if-let* ((file
-             (caar (citar-file--get-note-filename
-                    key
-                    citar-notes-paths '("org"))))
-            (file-exists (file-exists-p file)))
-      (funcall citar-file-open-function file)
-    (let* ((uuid (org-id-new))
-           (template (citar-get-template 'note))
-           (note-meta
-            (when template
-              (citar--format-entry-no-widths
-               entry
-               template)))
-           (org-id (when (member 'org-id citar-file-note-org-include)
-                     (concat "\n:ID:   " uuid)))
-           (org-roam-key (when (member 'org-roam-ref citar-file-note-org-include)
-                           (concat "\n:ROAM_REFS: @" key)))
-           (prop-drawer (or org-id org-roam-key))
-           (content
-            (concat (when prop-drawer ":PROPERTIES:")
-                    org-roam-key org-id
-                    (when prop-drawer "\n:END:\n")
-                    note-meta "\n")))
-      (funcall citar-file-open-function file)
-      ;; This just overrides other template insertion.
-      (erase-buffer)
-      (when template (insert content)))))
 
 (defun citar-file--get-note-filename (key dirs extensions)
   "Return existing or new filename for KEY in DIRS with extension in EXTENSIONS.

--- a/citar-latex.el
+++ b/citar-latex.el
@@ -1,0 +1,128 @@
+;;; citar-latex.el --- Latex adapter for citar -*- lexical-binding: t; -*-
+;;
+;; Copyright (C) 2021 Bruce D'Arcus
+;;
+;; Author: Bruce D'Arcus <https://github.com/bdarcus>
+;; Maintainer: Bruce D'Arcus <https://github.com/bdarcus>
+;; Created: February 27, 2021
+;; License: GPL-3.0-or-later
+;; Version: 0.4
+;; Homepage: https://github.com/bdarcus/citar
+;; Package-Requires: ((emacs "26.3"))
+;;
+;; This file is not part of GNU Emacs.
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+;;
+;;; Commentary:
+;;
+;; A small package that provides the functions required to use citar
+;; with latex.
+;;
+;; Simply loading this file will enable manipulating the citations with
+;; commands provided by citar.
+;;
+;;; Code:
+
+(require 'citar)
+(require 'tex)
+(require 'reftex-parse)
+
+(defvar citar-major-mode-functions)
+
+(defcustom citar-latex-cite-commands
+  '((("cite" "Cite" "citet" "Citet" "parencite"
+      "Parencite" "footcite" "footcitetext" "textcite" "Textcite"
+      "smartcite" "Smartcite" "cite*" "parencite*" "autocite"
+      "Autocite" "autocite*" "Autocite*" "citeauthor" "Citeauthor"
+      "citeauthor*" "Citeauthor*" "citetitle" "citetitle*" "citeyear"
+      "citeyear*" "citedate" "citedate*" "citeurl" "fullcite"
+      "footfullcite" "notecite" "Notecite" "pnotecite" "Pnotecite"
+      "fnotecite") . (["Prenote"] ["Postnote"] t))
+    (("nocite" "supercite") . nil))
+  "Citation commands and their argument specs.
+
+The argument spec is the same as the args argument of
+`TeX-parse-macro'. When calling `citar-insert-citation' the keys
+will be inserted at the position where `TeX-parse-macro' leaves
+the point."
+  :group 'citar-latex
+  :type '(alist :key-type (repeat string)
+                :value-type sexp))
+
+(defcustom citar-latex-prompt-for-extra-arguments t
+  "Whether to prompt for additional arguments when inserting a citation."
+  :group 'citar-latex
+  :type 'boolean)
+
+(add-to-list 'citar-major-mode-functions
+             '((latex-mode) .
+               ((local-bib-files . citar-latex--local-bib-files)
+                (insert-keys . citar-latex--insert-keys)
+                (insert-citation . citar-latex--insert-citation)
+                (keys-at-point . citar-latex--keys-at-point))))
+
+(defun citar-latex--local-bib-files ()
+  "Local bibliographic for latex retrieved using reftex."
+  (reftex-access-scan-info t)
+  (ignore-errors (reftex-get-bibfile-list)))
+
+(defun citar-latex--keys-at-point ()
+  "Return a list of keys at point in a latex buffer."
+    (when (citar-latex-is-a-cite-command (TeX-current-macro))
+      (split-string (thing-at-point 'list t) "," t "[{} ]+")))
+
+(defun citar-latex--insert-keys (keys)
+  "Insert comma sperated KEYS in a latex buffer."
+  (insert (string-join keys ", ")))
+
+(defvar citar-latex-cite-command-history nil
+  "Variable for history of cite commands.")
+
+(defun citar-latex--insert-citation (keys &optional command)
+  "Insert a citation consisting of KEYS.
+
+If the command is inside a citation command keys are added to it. Otherwise
+a new command is started.
+
+If the optional COMMAND is provided use it, otherwise prompt for one.
+
+The availiable commands and how to provide them arguments are configured
+by `citar-latex-cite-commands'.
+
+If `citar-latex-prompt-for-extra-arguments' is `nil`, every
+command is assumed to have a single argument into which keys are
+inserted."
+  (when keys
+    (if (citar-latex-is-a-cite-command (TeX-current-macro))
+        (progn (skip-chars-forward "^,}")
+               (unless (equal ?} (preceding-char)) (insert ", ")))
+      (let ((macro (or command
+                       (completing-read "Cite command: "
+                                        (seq-mapcat #'car citar-latex-cite-commands)
+                                        nil nil nil
+                                        'citar-latex-cite-command-history nil nil))))
+        (TeX-parse-macro macro
+                         (when citar-latex-prompt-for-extra-arguments
+                           (cdr (citar-latex-is-a-cite-command macro))))))
+    (citar-latex--insert-keys keys)
+    (skip-chars-forward "^}") (forward-char 1)))
+
+(defun citar-latex-is-a-cite-command (command)
+  "Return element of `citar-latex-cite-commands` containing COMMAND."
+  (seq-find (lambda (x) (member command (car x)))
+                 citar-latex-cite-commands))
+
+(provide 'citar-latex)
+;;; citar-latex.el ends here

--- a/citar-latex.el
+++ b/citar-latex.el
@@ -66,13 +66,6 @@ the point."
   :group 'citar-latex
   :type 'boolean)
 
-(add-to-list 'citar-major-mode-functions
-             '((latex-mode) .
-               ((local-bib-files . citar-latex-local-bib-files)
-                (insert-keys . citar-latex-insert-keys)
-                (insert-citation . citar-latex-insert-citation)
-                (keys-at-point . citar-latex-keys-at-point))))
-
 ;;;###autoload
 (defun citar-latex-local-bib-files ()
   "Local bibliographic for latex retrieved using reftex."
@@ -120,7 +113,7 @@ inserted."
         (TeX-parse-macro macro
                          (when citar-latex-prompt-for-extra-arguments
                            (cdr (citar-latex-is-a-cite-command macro))))))
-    (citar-latex--insert-keys keys)
+    (citar-latex-insert-keys keys)
     (skip-chars-forward "^}") (forward-char 1)))
 
 (defun citar-latex-is-a-cite-command (command)

--- a/citar-latex.el
+++ b/citar-latex.el
@@ -68,29 +68,33 @@ the point."
 
 (add-to-list 'citar-major-mode-functions
              '((latex-mode) .
-               ((local-bib-files . citar-latex--local-bib-files)
-                (insert-keys . citar-latex--insert-keys)
-                (insert-citation . citar-latex--insert-citation)
-                (keys-at-point . citar-latex--keys-at-point))))
+               ((local-bib-files . citar-latex-local-bib-files)
+                (insert-keys . citar-latex-insert-keys)
+                (insert-citation . citar-latex-insert-citation)
+                (keys-at-point . citar-latex-keys-at-point))))
 
-(defun citar-latex--local-bib-files ()
+;;;###autoload
+(defun citar-latex-local-bib-files ()
   "Local bibliographic for latex retrieved using reftex."
   (reftex-access-scan-info t)
   (ignore-errors (reftex-get-bibfile-list)))
 
-(defun citar-latex--keys-at-point ()
+;;;###autoload
+(defun citar-latex-keys-at-point ()
   "Return a list of keys at point in a latex buffer."
     (when (citar-latex-is-a-cite-command (TeX-current-macro))
       (split-string (thing-at-point 'list t) "," t "[{} ]+")))
 
-(defun citar-latex--insert-keys (keys)
+;;;###autoload
+(defun citar-latex-insert-keys (keys)
   "Insert comma sperated KEYS in a latex buffer."
   (insert (string-join keys ", ")))
 
 (defvar citar-latex-cite-command-history nil
   "Variable for history of cite commands.")
 
-(defun citar-latex--insert-citation (keys &optional command)
+;;;###autoload
+(defun citar-latex-insert-citation (keys &optional command)
   "Insert a citation consisting of KEYS.
 
 If the command is inside a citation command keys are added to it. Otherwise

--- a/citar-markdown.el
+++ b/citar-markdown.el
@@ -1,0 +1,81 @@
+;;; citar-markdown.el --- Markdown adapter for citar -*- lexical-binding: t; -*-
+;;
+;; Copyright (C) 2021 Bruce D'Arcus
+;;
+;; Author: Bruce D'Arcus <https://github.com/bdarcus>
+;; Maintainer: Bruce D'Arcus <https://github.com/bdarcus>
+;; Created: February 27, 2021
+;; License: GPL-3.0-or-later
+;; Version: 0.4
+;; Homepage: https://github.com/bdarcus/citar
+;; Package-Requires: ((emacs "26.3"))
+;;
+;; This file is not part of GNU Emacs.
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+;;
+;;; Commentary:
+;;
+;; A small package that provides the functions required to use citar
+;; with markdown.
+;;
+;; Simply loading this file will enable manipulating the citations with
+;; commands provided by citar.
+;;
+;;; Code:
+
+(require 'citar)
+
+(defvar citar-major-mode-functions)
+
+(defcustom citar-markdown-prompt-for-extra-arguments t
+  "Whether to prompt for additional arguments when inserting a citation."
+  ;; REVIEW this maybe shouldn't be mode specific?
+  :group 'citar-markdown
+  :type 'boolean)
+
+(add-to-list 'citar-major-mode-functions
+             '((markdown-mode) .
+               ((local-bib-files . citar-markdown--local-bib-files)
+                (insert-keys . citar-markdown--insert-keys)
+                (insert-citation . citar-markdown--insert-citation)
+                (keys-at-point . citar-markdown--keys-at-point))))
+
+(defun citar-markdown--local-bib-files ()
+  "Return local bib files for markdown."
+  nil)
+
+(defun citar-markdown--keys-at-point ()
+  "Return a list of keys at point in a markdown buffer."
+  (error "TODO"))
+
+(defun citar-markdown--insert-keys (keys)
+  "Insert comma sperated KEYS in a markdown buffer."
+  (insert (mapconcat (lambda (k) (concat "@" k)) keys "; ")))
+
+(defun citar-markdown--insert-citation (keys)
+  "Insert a pandoc-style citation consisting of KEYS."
+  (let* ((prenote  (if citar-markdown-prompt-for-extra-arguments
+                       (read-from-minibuffer "Prenote: ")))
+         (postnote (if citar-markdown-prompt-for-extra-arguments
+                       (read-from-minibuffer "Postnote: ")))
+         (prenote  (if (string= "" prenote)  "" (concat prenote  " ")))
+         (postnote (if (string= "" postnote) "" (concat ", " postnote))))
+    (insert (format "[%s%s%s]"
+                    prenote
+                    (mapconcat (lambda (k) (concat "@" k)) keys "; ")
+                    postnote))))
+
+(provide 'citar-markdown)
+;;; citar-markdown.el ends here

--- a/citar-markdown.el
+++ b/citar-markdown.el
@@ -47,24 +47,16 @@
 
 (add-to-list 'citar-major-mode-functions
              '((markdown-mode) .
-               ((local-bib-files . citar-markdown--local-bib-files)
-                (insert-keys . citar-markdown--insert-keys)
-                (insert-citation . citar-markdown--insert-citation)
-                (keys-at-point . citar-markdown--keys-at-point))))
+               ((insert-keys . citar-markdown-insert-keys)
+                (insert-citation . citar-markdown-insert-citation))))
 
-(defun citar-markdown--local-bib-files ()
-  "Return local bib files for markdown."
-  nil)
-
-(defun citar-markdown--keys-at-point ()
-  "Return a list of keys at point in a markdown buffer."
-  (error "TODO"))
-
-(defun citar-markdown--insert-keys (keys)
+;;;###autoload
+(defun citar-markdown-insert-keys (keys)
   "Insert comma sperated KEYS in a markdown buffer."
   (insert (mapconcat (lambda (k) (concat "@" k)) keys "; ")))
 
-(defun citar-markdown--insert-citation (keys)
+;;;###autoload
+(defun citar-markdown-insert-citation (keys)
   "Insert a pandoc-style citation consisting of KEYS."
   (let* ((prenote  (if citar-markdown-prompt-for-extra-arguments
                        (read-from-minibuffer "Prenote: ")))

--- a/citar-markdown.el
+++ b/citar-markdown.el
@@ -45,11 +45,6 @@
   :group 'citar-markdown
   :type 'boolean)
 
-(add-to-list 'citar-major-mode-functions
-             '((markdown-mode) .
-               ((insert-keys . citar-markdown-insert-keys)
-                (insert-citation . citar-markdown-insert-citation))))
-
 ;;;###autoload
 (defun citar-markdown-insert-keys (keys)
   "Insert comma sperated KEYS in a markdown buffer."

--- a/citar-org.el
+++ b/citar-org.el
@@ -237,6 +237,38 @@ strings by style."
          (formatted-preview (truncate-string-to-width preview 50 nil 32)))
     (propertize formatted-preview 'face 'citar-org-style-preview)))
 
+;;; Org note function
+
+(defun citar-org-open-notes-default (key entry)
+  "Open a note file from KEY and ENTRY."
+  (if-let* ((file
+             (caar (citar-file--get-note-filename
+                    key
+                    citar-notes-paths '("org"))))
+            (file-exists (file-exists-p file)))
+      (funcall citar-file-open-function file)
+    (let* ((uuid (org-id-new))
+           (template (citar-get-template 'note))
+           (note-meta
+            (when template
+              (citar--format-entry-no-widths
+               entry
+               template)))
+           (org-id (when (member 'org-id citar-file-note-org-include)
+                     (concat "\n:ID:   " uuid)))
+           (org-roam-key (when (member 'org-roam-ref citar-file-note-org-include)
+                           (concat "\n:ROAM_REFS: @" key)))
+           (prop-drawer (or org-id org-roam-key))
+           (content
+            (concat (when prop-drawer ":PROPERTIES:")
+                    org-roam-key org-id
+                    (when prop-drawer "\n:END:\n")
+                    note-meta "\n")))
+      (funcall citar-file-open-function file)
+      ;; This just overrides other template insertion.
+      (erase-buffer)
+      (when template (insert content)))))
+
 ;;; Embark target finder
 
 (defun citar-org-citation-finder ()

--- a/citar-org.el
+++ b/citar-org.el
@@ -41,6 +41,7 @@
 
 (require 'citar)
 (require 'org)
+(require 'org-id)
 (require 'oc)
 (require 'oc-basic)
 (require 'oc-csl)
@@ -67,6 +68,12 @@
   :type '(choice
           (const long)
           (const short)))
+
+(defcustom citar-file-note-org-include nil
+  "The org note type."
+  :group 'citar
+  :type '(repeat (const :tag "Org ID" 'org-id)
+                 (const :tag "Org-Roam :ROAM_REF:" 'org-roam-ref)))
 
 (defcustom citar-org-style-targets nil
   "Export processor targets to include in styles list.
@@ -231,11 +238,18 @@ strings by style."
 
 (defun citar-org--style-preview-annote (style &optional _citation)
   "Annotate STYLE with CITATION preview."
-  ;; TODO rather than use the alist, run the export processors on the citation..
+  ;; TODO rather than use the alist, run the export processors on the citation.
   (let* ((preview (or (cdr (assoc style citar-org-style-preview-alist)) ""))
          ;; TODO look at how define-face does this.
          (formatted-preview (truncate-string-to-width preview 50 nil 32)))
     (propertize formatted-preview 'face 'citar-org-style-preview)))
+
+;;;###autoload
+(defun citar-org-local-bibs ()
+  "Return local bib file paths for org buffer."
+  (seq-difference
+   (org-cite-list-bibliography-files)
+   org-cite-global-bibliography))
 
 ;;; Org note function
 

--- a/citar-org.el
+++ b/citar-org.el
@@ -287,8 +287,23 @@ strings by style."
 
 (defun citar-org-citation-finder ()
   "Return org-cite citation keys at point as a list for `embark'."
-  (when-let ((keys (citar-get-key-org-cite)))
+  (when-let ((keys (citar-org-keys-at-point)))
     (cons 'oc-citation (citar--stringify-keys keys))))
+
+(defun citar-org-keys-at-point ()
+  "Return key at point for org-cite citation-reference."
+  (when-let (((eq major-mode 'org-mode))
+             (elt (org-element-context)))
+    (pcase (org-element-type elt)
+      ('citation-reference
+       (org-element-property :key elt))
+      ('citation
+       (org-cite-get-references elt t)))))
+
+(defun citar-org--insert-keys (keys)
+  "Insert KEYS in org-cite format."
+  (string-join (seq-map (lambda (key) (concat "@" key)) keys) ":"))
+
 
 ;;; Functions for editing/modifying citations
 

--- a/citar.el
+++ b/citar.el
@@ -192,7 +192,8 @@ If you use 'org-roam' and 'org-roam-bibtex', you can use
 
 (defcustom citar-major-mode-functions
   '(((org-mode) .
-     ((local-bib-files . citar-org-local-bibs)))
+     ((local-bib-files . citar-org-local-bibs)
+      (keys-at-point . citar-org-keys-at-point)))
     ((latex-mode) .
      ((local-bib-files . citar-latex-local-bib-files)
       (insert-keys . citar-latex-insert-keys)
@@ -669,10 +670,10 @@ FORMAT-STRING."
 ;;; Embark
 
 ;;;###autoload
-(defun citar-citation-key-at-point ()
-  "Return citation keys at point as a list for `embark'."
-  (when-let ((keys (or (citar-get-key-org-cite)
-                      (bibtex-completion-key-at-point))))
+(defun citar-keys-at-point ()
+  "Return the keys of the entry at point."
+  (when-let ((keys
+              (citar--major-mode-function 'keys-at-point)))
     (cons 'citation-key (citar--stringify-keys keys))))
 
 (defun citar--stringify-keys (keys)
@@ -681,7 +682,7 @@ FORMAT-STRING."
 
 ;;;###autoload
 (with-eval-after-load 'embark
-  (add-to-list 'embark-target-finders 'citar-citation-key-at-point)
+  (add-to-list 'embark-target-finders 'citar-keys-at-point)
   (add-to-list 'embark-keymap-alist '(bib-reference . citar-map))
   (add-to-list 'embark-keymap-alist '(citation-key . citar-buffer-map)))
 
@@ -843,7 +844,7 @@ With prefix, rebuild the cache before offering candidates."
 (defun citar-dwim ()
   "Run the default action on citation keys found at point."
   (interactive)
-  (if-let ((keys (cdr (citar-citation-key-at-point))))
+  (if-let ((keys (cdr (citar-keys-at-point))))
       ;; FIX how?
       (citar-run-default-action keys)))
 

--- a/citar.el
+++ b/citar.el
@@ -749,6 +749,12 @@ With prefix, rebuild the cache before offering candidates."
                                       (citar--local-files-to-cache))))
   (mapc (lambda (key) (bibtex-find-entry key t nil t)) (citar--extract-keys keys-entries))))
 
+(defun citar--open-entry (key)
+  "Open bibliographic entry asociated with the KEY."
+  (let ((bibtex-files
+         (seq-concatenate 'list citar-bibliography (citar--local-files-to-cache))))
+    (bibtex-find-entry key t nil t)))
+
 ;;;###autoload
 (defun citar-open-link (keys-entries)
   "Open URL or DOI link associated with the KEYS-ENTRIES in a browser.
@@ -803,28 +809,6 @@ With prefix, rebuild the cache before offering candidates."
  (bibtex-completion-insert-bibtex
   (citar--extract-keys
    keys-entries)))
-
-;;;###autoload
-(defun citar-add-pdf-attachment (keys-entries)
-  "Attach PDF(s) associated with the KEYS-ENTRIES to email.
-With prefix, rebuild the cache before offering candidates."
-  (interactive (list (citar-select-refs
-                      :rebuild-cache current-prefix-arg)))
- (bibtex-completion-add-PDF-attachment
-  (citar--extract-keys
-   keys-entries)))
-
-;;;###autoload
-(defun citar-add-pdf-to-library (keys-entries)
- "Add PDF associated with the KEYS-ENTRIES to library.
-The PDF can be added either from an open buffer, a file, or a
-URL.
-With prefix, rebuild the cache before offering candidates."
-  (interactive (list (citar-select-refs
-                      :rebuild-cache current-prefix-arg)))
-  (bibtex-completion-add-pdf-to-library
-   (citar--extract-keys
-    keys-entries)))
 
 ;;;###autoload
 (defun citar-run-default-action (keys)

--- a/citar.el
+++ b/citar.el
@@ -329,9 +329,14 @@ offering the selection candidates."
 
 (defun citar--major-mode-function (key &rest args)
   "Function for the major mode corresponding to KEY applied to ARGS."
-  (apply (alist-get key (cdr (seq-find (lambda (x) (memq major-mode (car x)))
-                                citar-major-mode-functions)))
-         args))
+  (let ((function
+         (alist-get
+          key
+          (cdr
+           (seq-find
+            (lambda (x) (memq major-mode (car x)))
+            citar-major-mode-functions)))))
+    (when function (apply function args))))
 
 (defun citar--local-files-to-cache ()
   "The local bibliographic files not included in the global bibliography."
@@ -673,7 +678,6 @@ FORMAT-STRING."
 ;;;###autoload
 (defun citar-open (keys-entries)
   "Open related resource (link or file) for KEYS-ENTRIES."
-  ;; TODO add links
   (interactive (list (citar-select-refs
                       :rebuild-cache current-prefix-arg)))
   (let* ((files

--- a/citar.el
+++ b/citar.el
@@ -191,12 +191,16 @@ If you use 'org-roam' and 'org-roam-bibtex', you can use
   :type 'function)
 
 (defcustom citar-major-mode-functions
-  '(((latex-mode) .
-     ((local-bib-files . citar-latex--local-bib-files)
-      (keys-at-point . citar-latex--keys-at-point)))
+  '(((org-mode) .
+     ((local-bib-files . citar-org-local-bibs)))
+    ((latex-mode) .
+     ((local-bib-files . citar-latex-local-bib-files)
+      (insert-keys . citar-latex-insert-keys)
+      (insert-citation . citar-latex-insert-citation)
+      (keys-at-point . citar-latex-keys-at-point)))
     ((markdown-mode) .
-     ((local-bib-files . citar-markdown--local-bib-files)
-      (insert-keys . citar-markdown--insert-keys))))
+     ((local-bib-files . citar-markdown-local-bib-files)
+      (insert-keys . citar-markdown-insert-keys))))
   "The variable determining the major mode specifc functionality.
 
 It is alist with keys being a list of major modes.
@@ -620,6 +624,7 @@ If FORCE-REBUILD-CACHE is t, force reload the cache."
   "Formats a BibTeX ENTRY for display in results list.
 WIDTH is the width for the * field, and the display format is governed by
 FORMAT-STRING."
+  ;; TODO remove s-format dependency, generalize to allow 'truncate' option
   (s-format
    format-string
    (lambda (raw-field)

--- a/citar.el
+++ b/citar.el
@@ -44,8 +44,6 @@
 (require 'bibtex-completion)
 (require 'parsebib)
 (require 's)
-;; Not ideal, find a better FIX
-(require 'oc)
 
 (declare-function org-element-context "org-element")
 (declare-function org-element-property "org-element")
@@ -649,25 +647,7 @@ FORMAT-STRING."
      (let ((field-names (split-string raw-field "[ ]+")))
        (citar-display-value field-names entry)))))
 
-;;; At-point functions
-
-;;; Org-cite
-
-(defun citar-get-key-org-cite ()
-  "Return key at point for org-cite citation-reference."
-  (when-let (((eq major-mode 'org-mode))
-             (elt (org-element-context)))
-    (pcase (org-element-type elt)
-      ('citation-reference
-       (org-element-property :key elt))
-      ('citation
-       (org-cite-get-references elt t)))))
-
-(defun citar--insert-keys-org-cite (keys)
-  "Insert KEYS in org-cite format."
-  (string-join (seq-map (lambda (key) (concat "@" key)) keys) ":"))
-
-;;; Embark
+;;; At-point functions for Embark
 
 ;;;###autoload
 (defun citar-keys-at-point ()

--- a/citar.el
+++ b/citar.el
@@ -828,6 +828,31 @@ With prefix, rebuild the cache before offering candidates."
    (citar--extract-keys keys-entries)))
 
 ;;;###autoload
+(defun citar-add-pdf-attachment (keys-entries)
+  "Attach PDF(s) associated with the KEYS-ENTRIES to email.
+With prefix, rebuild the cache before offering candidates."
+  (interactive (list (citar-select-refs
+                      :rebuild-cache current-prefix-arg)))
+ (bibtex-completion-add-PDF-attachment
+  (citar--extract-keys
+   keys-entries)))
+
+;;;###autoload
+(defun citar-add-pdf-to-library (keys-entries)
+ "Add PDF associated with the KEYS-ENTRIES to library.
+The PDF can be added either from an open buffer, a file, or a
+URL.
+With prefix, rebuild the cache before offering candidates."
+  (interactive (list (citar-select-refs
+                      :rebuild-cache current-prefix-arg)))
+  (bibtex-completion-add-pdf-to-library
+   (citar--extract-keys
+    keys-entries)))
+
+(make-obsolete 'citar-add-pdf-to-library nil "0.9")
+(make-obsolete 'citar-add-pdf-attachment nil "0.9")
+
+;;;###autoload
 (defun citar-run-default-action (keys)
   "Run the default action `citar-default-action' on KEYS."
   (let* ((keys-parsed

--- a/citar.el
+++ b/citar.el
@@ -744,10 +744,11 @@ With prefix, rebuild the cache before offering candidates."
 With prefix, rebuild the cache before offering candidates."
   (interactive (list (citar-select-refs
                       :rebuild-cache current-prefix-arg)))
- (let ((bibtex-files (seq-concatenate 'list
-                                      citar-bibliography
-                                      (citar--local-files-to-cache))))
-  (mapc (lambda (key) (bibtex-find-entry key t nil t)) (citar--extract-keys keys-entries))))
+  ;; REVIEW unclear what the UX here should be when
+  ;;        opening multiple entries from the same file.
+  (let ((keys (citar--extract-keys keys-entries)))
+    (dolist (key keys)
+      (citar--open-entry key))))
 
 (defun citar--open-entry (key)
   "Open bibliographic entry asociated with the KEY."
@@ -777,8 +778,7 @@ With prefix, rebuild the cache before offering candidates."
                       :rebuild-cache current-prefix-arg)))
   ;; TODO
   (citar--major-mode-function 'insert-citation
-   (citar--extract-keys
-    keys-entries)))
+   (citar--extract-keys keys-entries)))
 
 ;;;###autoload
 (defun citar-insert-reference (keys-entries)
@@ -787,8 +787,7 @@ With prefix, rebuild the cache before offering candidates."
   (interactive (list (citar-select-refs
                       :rebuild-cache current-prefix-arg)))
   (bibtex-completion-insert-reference
-   (citar--extract-keys
-    keys-entries)))
+   (citar--extract-keys keys-entries)))
 
 ;;;###autoload
 (defun citar-insert-keys (keys-entries)
@@ -797,8 +796,7 @@ With prefix, rebuild the cache before offering candidates."
   (interactive (list (citar-select-refs
                       :rebuild-cache current-prefix-arg)))
  (citar--major-mode-function 'insert-keys
-  (citar--extract-keys
-   keys-entries)))
+  (citar--extract-keys keys-entries)))
 
 ;;;###autoload
 (defun citar-insert-bibtex (keys-entries)
@@ -806,9 +804,9 @@ With prefix, rebuild the cache before offering candidates."
 With prefix, rebuild the cache before offering candidates."
   (interactive (list (citar-select-refs
                       :rebuild-cache current-prefix-arg)))
- (bibtex-completion-insert-bibtex
-  (citar--extract-keys
-   keys-entries)))
+  ;; TODO use with-temp-buffer + citar--open-entry to replace?
+  (bibtex-completion-insert-bibtex
+   (citar--extract-keys keys-entries)))
 
 ;;;###autoload
 (defun citar-run-default-action (keys)


### PR DESCRIPTION
Another big step to removing the bibtex-completion dependency.

- add a new major-mode "adapter" design
- add citar-latex and citar-markdown based on above
- move around code and rename symbols accordingly
- rewrite citar-insert-keys, citar-insert-citation
- replace bibtex-completion-at-point with citar-keys-at-point

@aikrahguzar did most of this work.

------
TODO:

1. [X] docs
2. [X] deprecate "add"/"attach" pdf commands 
3. [X] move org-cite target finder to `citar-org`, adjust [code](https://github.com/bdarcus/citar/blob/62a6ca420fb39b6f64a3b54ab415c9dd67a404b0/citar.el#L672)
4. [ ] change `citar-major-mode-function` from using `major-mode` to `derived-mode-p` (but I'm not sure how to do that with this code ATM; may defer to this to a later PR)
5. [ ] test

-------
Given how much #307 has drifted from main, let's use this instead and GTM.

Aside from rebasing and resolving conflicts and fixing a few things, I also added a similar, simpler, `citar-markdown` for the pandoc syntax, though it doesn't work ATM. I did this in part to support markdown, but also to test the generality of the design. Since it doesn't work, there may be some issues to resolve there.

To me the remaining questions are:

1. how to handle the richer biblatex model? (probably defer worrying about it, though per below, the at-point stuff doesn't quite work here)
2. we should move some of the functions (like the org target finder), and align `citar-org` with these other two.
3. whether to tie to derived-mode rather than major-mode?
4. why the markdown one doesn't work, and how to fix it?
5. should we add a "notes-function" to the major-mode functions list, so we can put the org note function in `citar-org`?

Perhaps 4 is the only blocker? 

See also review comments below; 

cc @aikrahguzar 

@roshanshariff can you review this, as it has implications for the other details we were discussing in #355. See my comments below, for example.
