### PR TITLE
feat: completing-read citar-select-ref option

### DIFF
--- a/citar-file.el
+++ b/citar-file.el
@@ -43,20 +43,6 @@
   :group 'citar
   :type '(boolean))
 
-(defcustom citar-file-open-note-function
-  'citar-file-open-notes-default-org
-  "Function to open and existing or create a new note.
-
-A note function must take two arguments:
-
-KEY: a string to represent the citekey
-ENTRY: an alist with the structured data (title, author, etc.)
-
-If you use 'org-roam' and 'org-roam-bibtex', you can use
-'orb-citar-edit-note' for this value."
-  :group 'citar
-  :type '(function))
-
 (defcustom citar-file-parser-functions
   '(citar-file-parser-default)
   "List of functions to parse file field."

--- a/citar.el
+++ b/citar.el
@@ -65,7 +65,7 @@
 (defvar embark-target-finders)
 (defvar embark-general-map)
 (defvar embark-meta-map)
-(defvar citar-file-open-note-function)
+(defvar citar-org-open-note-function)
 (defvar citar-file-extensions)
 (defvar citar-file-open-prompt)
 (defvar citar-file-variable)
@@ -181,7 +181,6 @@ If you use 'org-roam' and 'org-roam-bibtex', you can use
 'orb-bibtex-actions-edit-note' for this value."
   :group 'citar
   :type 'function)
-
 
 (defcustom citar-at-point-function 'citar-dwim
   "The function to run for 'citar-at-point'."
@@ -757,11 +756,11 @@ With prefix, rebuild the cache before offering candidates."
   (interactive (list (citar-select-refs
                       :rebuild-cache current-prefix-arg)))
   (when (and (null citar-notes-paths)
-             (equal citar-file-open-note-function
-                    'citar-file-open-notes-default-org))
+             (equal citar-open-note-function
+                    'citar-org-open-notes-default))
     (message "You must set 'citar-notes-paths' to open notes with default notes function"))
   (dolist (key-entry keys-entries)
-    (funcall citar-file-open-note-function
+    (funcall citar-open-note-function
              (car key-entry) (cdr key-entry))))
 
 ;;;###autoload

--- a/citar.el
+++ b/citar.el
@@ -765,16 +765,13 @@ With prefix, rebuild the cache before offering candidates."
              (car key-entry) (cdr key-entry))))
 
 ;;;###autoload
-(defun citar-open-entry (keys-entries)
-  "Open bibliographic entry associated with the KEYS-ENTRIES.
+(defun citar-open-entry (key-entry)
+  "Open bibliographic entry associated with the KEY-ENTRY.
 With prefix, rebuild the cache before offering candidates."
   (interactive (list (citar-select-refs
                       :rebuild-cache current-prefix-arg)))
-  ;; REVIEW unclear what the UX here should be when
-  ;;        opening multiple entries from the same file.
-  (let ((keys (citar--extract-keys keys-entries)))
-    (dolist (key keys)
-      (citar--open-entry key))))
+  (let ((key (citar--extract-keys key-entry)))
+    (citar--open-entry (car key))))
 
 (defun citar--open-entry (key)
   "Open bibliographic entry asociated with the KEY."


### PR DESCRIPTION
Three commits:

1. a new completing-read-based `citar-select-ref` to complement the existing one.
2. changing `citar-open-entry` to use 1.
3. bugfix for notes function

I bundle the first two here in part to see how well 1 will work with embark.

Turns out: well.

cc @roshanshariff - WDYT?