### PR TITLE
remove bibtex-completion dependency

### DIFF
--- a/README.org
+++ b/README.org
@@ -342,15 +342,15 @@ For example, if point:
 The "activate processor" runs the list of functions in ~oc-bibtex-activation-functions~, which by default is the ~basic~ processor from ~oc-basic~ to provide fontification, and also a little function that adds a keymap for editing citations at point.
 That keymap includes the following bindings that provide additional citation and citation-reference editing options.
 
-| key       | binding                                 |
-|-----------+-----------------------------------------|
+| key       | binding                        |
+|-----------+--------------------------------|
 | C-d       | oc-citar-delete-citation       |
 | C-k       | oc-citar-kill-citation         |
 | S-<left>  | oc-citar-shift-reference-left  |
 | S-<right> | oc-citar-shift-reference-right |
-| C-p       | oc-citar-update-pre-suffix     |
+| M-p       | oc-citar-update-pre-suffix     |
 | <mouse-1> | citar-dwim                     |
-| <mouse-3> | embark-act                              |
+| <mouse-3> | embark-act                     |
 
 
 The "follow processor" provides at-point functionality accessible via the =org-open-at-point= command.

--- a/citar-latex.el
+++ b/citar-latex.el
@@ -36,7 +36,7 @@
 ;;; Code:
 
 (require 'citar)
-(require 'tex)
+(require 'tex nil t)
 (require 'reftex-parse)
 
 (defvar citar-major-mode-functions)
@@ -75,8 +75,10 @@ the point."
 ;;;###autoload
 (defun citar-latex-keys-at-point ()
   "Return a list of keys at point in a latex buffer."
-    (when (citar-latex-is-a-cite-command (TeX-current-macro))
-      (split-string (thing-at-point 'list t) "," t "[{} ]+")))
+  (unless (fboundp 'TeX-current-macro)
+    (error "Please install AUCTeX"))
+  (when (citar-latex-is-a-cite-command (TeX-current-macro))
+    (split-string (thing-at-point 'list t) "," t "[{} ]+")))
 
 ;;;###autoload
 (defun citar-latex-insert-keys (keys)
@@ -101,6 +103,8 @@ by `citar-latex-cite-commands'.
 If `citar-latex-prompt-for-extra-arguments' is `nil`, every
 command is assumed to have a single argument into which keys are
 inserted."
+  (unless (fboundp 'TeX-current-macro)
+    (error "Please install AUCTeX"))
   (when keys
     (if (citar-latex-is-a-cite-command (TeX-current-macro))
         (progn (skip-chars-forward "^,}")

--- a/citar-org.el
+++ b/citar-org.el
@@ -127,7 +127,7 @@ Each function takes one argument, a citation."
     (define-key map (kbd "C-k") '("kill citation" . citar-org-kill-citation))
     (define-key map (kbd "S-<left>") '("shift left" . citar-org-shift-reference-left))
     (define-key map (kbd "S-<right>") '("shift right" . citar-org-shift-reference-right))
-    (define-key map (kbd "C-p") '("update prefix/suffix" . citar-org-update-pre-suffix))
+    (define-key map (kbd "M-p") '("update prefix/suffix" . citar-org-update-pre-suffix))
     map)
   "Keymap for interacting with org citations at point."
   :group 'citar-org

--- a/citar.el
+++ b/citar.el
@@ -72,6 +72,7 @@
 (defvar citar-file-extensions)
 (defvar citar-file-open-prompt)
 (defvar citar-file-variable)
+(defvar org-cite-bibliography)
 
 ;;; Variables
 
@@ -85,7 +86,7 @@
   "Face used to highlight content in `citar' candidates."
   :group 'citar)
 
-(defcustom citar-bibliography nil
+(defcustom citar-bibliography org-cite-bibliography
   "A list of bibliography files."
   :group 'citar
   :type '(repeat file))

--- a/citar.el
+++ b/citar.el
@@ -200,8 +200,7 @@ If you use 'org-roam' and 'org-roam-bibtex', you can use
       (insert-citation . citar-latex-insert-citation)
       (keys-at-point . citar-latex-keys-at-point)))
     ((markdown-mode) .
-     ((local-bib-files . citar-markdown-local-bib-files)
-      (insert-keys . citar-markdown-insert-keys))))
+     ((insert-keys . citar-markdown-insert-keys))))
   "The variable determining the major mode specifc functionality.
 
 It is alist with keys being a list of major modes.


### PR DESCRIPTION
Fix #246.

Also fix #367.

-----

Per suggestion at https://github.com/bdarcus/citar/issues/246#issuecomment-961584996, this should do it @minad @roshanshariff.

The only issue is the `citar--insert-entry` function doesn't work correctly.

Any ideas?

I could just remove that entirely, and instead use embark for that?