### PR TITLE
Fix pcase use in citar-filenotify

### DIFF
--- a/citar-filenotify.el
+++ b/citar-filenotify.el
@@ -79,8 +79,8 @@ If it is other than 'global or 'local invalidate both"
 
 CHANGE refers to the notify argument."
   (pcase (cadr change)
-    ('(nil changed) (funcall func scope))
-    ('(created deleted renamed)
+    ((or 'nil 'changed) (funcall func scope))
+    ((or 'created 'deleted 'renamed)
      (if (member
           (nth 2 change)
           (seq-concatenate 'list


### PR DESCRIPTION
Debugging why my cache wasn’t correctly invalidated, the previous pcase patterns didn’t seem to work at all. I’m constantly confused by pcase however, so I’m not sure if this is the best way, but it seems to work correctly.