### PR TITLE
Headers

### DIFF
--- a/citar-file.el
+++ b/citar-file.el
@@ -2,14 +2,20 @@
 ;;
 ;; Copyright (C) 2021 Bruce D'Arcus
 ;;
-;; Author: Bruce D'Arcus <https://github.com/bdarcus>
-;; Maintainer: Bruce D'Arcus <bdarcus@gmail.com>
-;; Created: August 17, 2021
-;; Version: 0.8
-;; Homepage: https://github.com/bdarcus/citar
-;; Package-Requires: ((emacs "26.3"))
-;;
 ;; This file is not part of GNU Emacs.
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
 ;;
 ;;; Commentary:
 ;;

--- a/citar-filenotify.el
+++ b/citar-filenotify.el
@@ -2,15 +2,20 @@
 ;;
 ;; Copyright (C) 2021 Bruce D'Arcus
 ;;
-;; Author: Bruce D'Arcus <https://github.com/bdarcus>
-;; Maintainer: Bruce D'Arcus <bdarcus@gmail.com>
-;; Created: August 17, 2021
-;; Version: 0.8
-;; Keywords: bib files frames games hardware help
-;; Homepage: https://github.com/bdarcus/citar
-;; Package-Requires: ((emacs "26.3"))
-;;
 ;; This file is not part of GNU Emacs.
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
 ;;
 ;;; Commentary:
 ;;

--- a/citar-latex.el
+++ b/citar-latex.el
@@ -1,17 +1,9 @@
 ;;; citar-latex.el --- Latex adapter for citar -*- lexical-binding: t; -*-
-;;
+
 ;; Copyright (C) 2021 Bruce D'Arcus
-;;
-;; Author: Bruce D'Arcus <https://github.com/bdarcus>
-;; Maintainer: Bruce D'Arcus <https://github.com/bdarcus>
-;; Created: February 27, 2021
-;; License: GPL-3.0-or-later
-;; Version: 0.8
-;; Homepage: https://github.com/bdarcus/citar
-;; Package-Requires: ((emacs "26.3"))
-;;
+
 ;; This file is not part of GNU Emacs.
-;;
+
 ;; This program is free software: you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
 ;; the Free Software Foundation, either version 3 of the License, or
@@ -24,15 +16,15 @@
 
 ;; You should have received a copy of the GNU General Public License
 ;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
-;;
+
 ;;; Commentary:
-;;
+
 ;; A small package that provides the functions required to use citar
 ;; with latex.
-;;
+
 ;; Simply loading this file will enable manipulating the citations with
 ;; commands provided by citar.
-;;
+
 ;;; Code:
 
 (require 'citar)

--- a/citar-markdown.el
+++ b/citar-markdown.el
@@ -1,17 +1,9 @@
 ;;; citar-markdown.el --- Markdown adapter for citar -*- lexical-binding: t; -*-
-;;
+
 ;; Copyright (C) 2021 Bruce D'Arcus
-;;
-;; Author: Bruce D'Arcus <https://github.com/bdarcus>
-;; Maintainer: Bruce D'Arcus <https://github.com/bdarcus>
-;; Created: October 31, 2021
-;; License: GPL-3.0-or-later
-;; Version: 0.8
-;; Homepage: https://github.com/bdarcus/citar
-;; Package-Requires: ((emacs "26.3"))
-;;
+
 ;; This file is not part of GNU Emacs.
-;;
+
 ;; This program is free software: you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
 ;; the Free Software Foundation, either version 3 of the License, or
@@ -24,15 +16,15 @@
 
 ;; You should have received a copy of the GNU General Public License
 ;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
-;;
+
 ;;; Commentary:
-;;
+
 ;; A small package that provides the functions required to use citar
 ;; with markdown.
-;;
+
 ;; Simply loading this file will enable manipulating the citations with
 ;; commands provided by citar.
-;;
+
 ;;; Code:
 
 (require 'citar)

--- a/citar-org.el
+++ b/citar-org.el
@@ -1,17 +1,9 @@
 ;;; citar-org.el --- Org-cite support for citar -*- lexical-binding: t; -*-
-;;
+
 ;; Copyright (C) 2021 Bruce D'Arcus
-;;
-;; Author: Bruce D'Arcus <https://github.com/bdarcus>
-;; Maintainer: Bruce D'Arcus <https://github.com/bdarcus>
-;; Created: July 11, 2021
-;; License: GPL-3.0-or-later
-;; Version: 0.8
-;; Homepage: https://github.com/bdarcus/citar
-;; Package-Requires: ((emacs "26.3")(org "9.5"))
-;;
+
 ;; This file is not part of GNU Emacs.
-;;
+
 ;; This program is free software: you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
 ;; the Free Software Foundation, either version 3 of the License, or
@@ -24,19 +16,19 @@
 
 ;; You should have received a copy of the GNU General Public License
 ;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
-;;
+
 ;;; Commentary:
-;;
+
 ;;  This is a small package that integrates citar and org-cite.  It
 ;;  provides a simple org-cite processor with "follow", "insert", and
 ;;  "activate" capabilities.
-;;
+
 ;;  Simply load this file (or its generated autoloads) and it will
 ;;  make the processor available to 'org-cite'.  To instruct org-cite
 ;;  to use citar, set one or more of the customization variables
 ;;  'org-cite-activate-processor', 'org-cite-follow-processor', and
 ;;  'org-cite-insert-processor' to the symbol 'citar.
-;;
+
 ;;; Code:
 
 (require 'citar)

--- a/citar-org.el
+++ b/citar-org.el
@@ -84,7 +84,7 @@ Each function takes one argument, a citation."
 
 ;;; Keymaps
 
-(defcustom citar-org-map
+(defvar citar-org-map
   (let ((map (make-sparse-keymap)))
     (define-key map (kbd "o") '("open source (file or link)" . citar-open))
     (define-key map (kbd "e") '("open bibtex entry" . citar-open-entry))
@@ -93,11 +93,9 @@ Each function takes one argument, a citation."
     (define-key map (kbd "n") '("open notes" . citar-open-notes))
     (define-key map (kbd "r") '("refresh" . citar-refresh))
     map)
-  "Keymap for org-cite Embark minibuffer functionality."
-  :group 'citar-org
-  :type '(restricted-sexp :match-alternatives (keymapp)))
+  "Keymap for org-cite Embark minibuffer functionality.")
 
-(defcustom citar-org-buffer-map
+(defvar citar-org-buffer-map
   (let ((map (make-sparse-keymap)))
     (define-key map (kbd "o") '("open source (file or link)" . citar-open))
     (define-key map (kbd "e") '("open bibtex entry" . citar-open-entry))
@@ -106,11 +104,9 @@ Each function takes one argument, a citation."
     (define-key map (kbd "n") '("open notes" . citar-open-notes))
     (define-key map (kbd "r") '("refresh" . citar-refresh))
     map)
-  "Keymap for org-cite Embark at-point functionality."
-  :group 'citar-org
-  :type '(restricted-sexp :match-alternatives (keymapp)))
+  "Keymap for org-cite Embark at-point functionality.")
 
-(defcustom citar-org-citation-map
+(defvar citar-org-citation-map
   (let ((map (make-sparse-keymap)))
     (define-key map (kbd "<mouse-1>") '("default action" . citar-dwim))
     (with-eval-after-load 'embark
@@ -121,9 +117,7 @@ Each function takes one argument, a citation."
     (define-key map (kbd "S-<right>") '("shift right" . citar-org-shift-reference-right))
     (define-key map (kbd "M-p") '("update prefix/suffix" . citar-org-update-pre-suffix))
     map)
-  "Keymap for interacting with org citations at point."
-  :group 'citar-org
-  :type '(restricted-sexp :match-alternatives (keymapp)))
+  "Keymap for interacting with org citations at point.")
 
 ;; TODO maybe connvert to defcustoms. But this is not really the right approach;
 ;; better to just run the export processors to get the previews. But we need

--- a/citar.el
+++ b/citar.el
@@ -240,8 +240,7 @@ point."
 
 ;;; Keymaps
 
-;;;###autoload
-(defcustom citar-map
+(defvar citar-map
   (let ((map (make-sparse-keymap)))
     (define-key map (kbd "b") '("insert bibtex" . citar-insert-bibtex))
     (define-key map (kbd "c") '("insert citation" . citar-insert-citation))
@@ -257,12 +256,9 @@ point."
     ;; https://github.com/oantolin/embark/issues/251
     (define-key map (kbd "RET") '("default action" . citar-run-default-action))
     map)
-  "Keymap for Embark minibuffer actions."
-  :group 'oc-citar
-  :type '(restricted-sexp :match-alternatives (keymapp)))
+  "Keymap for Embark minibuffer actions.")
 
-;;;###autoload
-(defcustom citar-buffer-map
+(defvar citar-buffer-map
   (let ((map (make-sparse-keymap)))
     (define-key map (kbd "o") '("open source document" . citar-open))
     (define-key map (kbd "e") '("open bibtex entry" . citar-open-entry))
@@ -274,9 +270,7 @@ point."
     ;; https://github.com/oantolin/embark/issues/251
     (define-key map (kbd "RET") '("default action" . citar-run-default-action))
     map)
-  "Keymap for Embark citation-key actions."
-  :group 'citar
-  :type '(restricted-sexp :match-alternatives (keymapp)))
+  "Keymap for Embark citation-key actions.")
 
 ;;; Completion functions
 

--- a/citar.el
+++ b/citar.el
@@ -1,17 +1,17 @@
 ;;; citar.el --- Bibliographic commands based on completing-read -*- lexical-binding: t; -*-
-;;
+
 ;; Copyright (C) 2021 Bruce D'Arcus
-;;
+
 ;; Author: Bruce D'Arcus <https://github.com/bdarcus>
 ;; Maintainer: Bruce D'Arcus <https://github.com/bdarcus>
 ;; Created: February 27, 2021
 ;; License: GPL-3.0-or-later
 ;; Version: 0.8
 ;; Homepage: https://github.com/bdarcus/citar
-;; Package-Requires: ((emacs "27.1") (s "1.12") (parsebib "3.0"))
-;;
+;; Package-Requires: ((emacs "27.1") (s "1.12") (parsebib "3.0") (org "9.5"))
+
 ;; This file is not part of GNU Emacs.
-;;
+
 ;; This program is free software: you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
 ;; the Free Software Foundation, either version 3 of the License, or
@@ -24,16 +24,16 @@
 
 ;; You should have received a copy of the GNU General Public License
 ;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
-;;
+
 ;;; Commentary:
-;;
+
 ;;  A completing-read front-end for browsing and acting on bibliographic data.
-;;
+
 ;;  When used with vertico/selectrum/icomplete-vertical, embark, and marginalia,
 ;;  it provides similar functionality to helm-bibtex and ivy-bibtex: quick
 ;;  filtering and selecting of bibliographic entries from the minibuffer, and
 ;;  the option to run different commands against them.
-;;
+
 ;;; Code:
 
 (eval-when-compile
@@ -86,7 +86,7 @@
   "Face used to highlight content in `citar' candidates."
   :group 'citar)
 
-(defcustom citar-bibliography org-cite-bibliography
+(defcustom citar-bibliography nil
   "A list of bibliography files."
   :group 'citar
   :type '(repeat file))


### PR DESCRIPTION
Two small corrections regarding compilation/installation. The headers should have the simpler form at least as long as the files are distributed as a single package.