### PR TITLE
Install embark general maps as parent keymap

### DIFF
--- a/citar-org.el
+++ b/citar-org.el
@@ -386,6 +386,8 @@ strings by style."
 ;; Embark configuration for org-cite
 
 (with-eval-after-load 'embark
+  (set-keymap-parent citar-org-map embark-general-map)
+  (set-keymap-parent citar-org-buffer-map embark-general-map)
   (add-to-list 'embark-target-finders 'citar-org-citation-finder)
   (add-to-list 'embark-keymap-alist '(bib-reference . citar-org-map))
   (add-to-list 'embark-keymap-alist '(oc-citation . citar-org-buffer-map))

--- a/citar.el
+++ b/citar.el
@@ -676,6 +676,8 @@ FORMAT-STRING."
 
 ;;;###autoload
 (with-eval-after-load 'embark
+  (set-keymap-parent citar-map embark-general-map)
+  (set-keymap-parent citar-buffer-map embark-general-map)
   (add-to-list 'embark-target-finders 'citar-keys-at-point)
   (add-to-list 'embark-keymap-alist '(bib-reference . citar-map))
   (add-to-list 'embark-keymap-alist '(citation-key . citar-buffer-map)))


### PR DESCRIPTION
This change is questionable. I know that you dislike that the general Embark
actions are always there since they clutter which-key. Unfortunately without
this change Embark is badly broken. We need at least the C-h=embark-keymap-help
action. Furthermore in the minibuffer we would still like to have the
keybindings for embark-export/collect-snapshot etc.