### PR TITLE
Fix embark autoloads

### DIFF
--- a/citar.el
+++ b/citar.el
@@ -676,9 +676,11 @@ FORMAT-STRING."
 
 ;;;###autoload
 (with-eval-after-load 'embark
+  (add-to-list 'embark-target-finders 'citar-keys-at-point))
+
+(with-eval-after-load 'embark
   (set-keymap-parent citar-map embark-general-map)
   (set-keymap-parent citar-buffer-map embark-general-map)
-  (add-to-list 'embark-target-finders 'citar-keys-at-point)
   (add-to-list 'embark-keymap-alist '(bib-reference . citar-map))
   (add-to-list 'embark-keymap-alist '(citation-key . citar-buffer-map)))
 


### PR DESCRIPTION
With commit ec0695ba (PR #374), the citar keymaps are no longer autoloaded and therefore cannot be referred to by the autoloaded `with-eval-after-load` form for embark. This causes an error at emacs initialization.

This change splits the embark `with-eval-after-load` into two parts: the first is autoloaded and adds the target finder, while the second deals with the keymaps. This should be fine because embark will never need the citar keymaps unless it has (1) run the citar target finder, or (2) been invoked from a citar command.