### PR TITLE
align insert citation behavior, consolidate Embark maps

### DIFF
--- a/citar-latex.el
+++ b/citar-latex.el
@@ -72,11 +72,6 @@ the point."
   (when (citar-latex-is-a-cite-command (TeX-current-macro))
     (split-string (thing-at-point 'list t) "," t "[{} ]+")))
 
-;;;###autoload
-(defun citar-latex-insert-keys (keys)
-  "Insert comma sperated KEYS in a latex buffer."
-  (insert (string-join keys ", ")))
-
 (defvar citar-latex-cite-command-history nil
   "Variable for history of cite commands.")
 

--- a/citar-latex.el
+++ b/citar-latex.el
@@ -64,13 +64,59 @@ the point."
   (reftex-access-scan-info t)
   (ignore-errors (reftex-get-bibfile-list)))
 
+(defun citar-latex--macro-bounds ()
+  "Returns the bounds of the citation macro at point.
+Returns a pair of buffer positions indicating the beginning and
+end of the enclosing citation macro, or nil if point is not
+inside a citation macro.  Moves point to the beginning of the
+macro."
+  (unless (fboundp 'TeX-find-macro-boundaries)
+    (error "Please install AUCTeX."))
+  (save-excursion
+    (when-let* ((bounds (TeX-find-macro-boundaries))
+                (macro (progn (goto-char (car bounds))
+                              (looking-at (concat (regexp-quote TeX-esc)
+                                                  "\\([@A-Za-z]+\\)"))
+                              (match-string-no-properties 1))))
+      (when (citar-latex-is-a-cite-command macro)
+        bounds))))
+
 ;;;###autoload
-(defun citar-latex-keys-at-point ()
-  "Return a list of keys at point in a latex buffer."
-  (unless (fboundp 'TeX-current-macro)
-    (error "Please install AUCTeX"))
-  (when (citar-latex-is-a-cite-command (TeX-current-macro))
-    (split-string (thing-at-point 'list t) "," t "[{} ]+")))
+(defun citar-latex-key-at-point ()
+  "Returns (KEY . BOUNDS), where KEY is the citation key at point
+and BOUNDS is a pair of buffer positions.  Returns nil if there
+is no key at point."
+  (save-excursion
+    (when-let* ((bounds (citar-latex--macro-bounds))
+                (keych "^,{}")
+                (beg (progn (skip-chars-backward keych (car bounds)) (point)))
+                (end (progn (skip-chars-forward keych (cdr bounds)) (point)))
+                (pre (buffer-substring-no-properties (car bounds) beg))
+                (post (buffer-substring-no-properties end (cdr bounds))))
+      (and (string-match-p "{\\([^{}]*,\\)?\\'" pre)  ; preceded by { ... ,
+           (string-match-p "\\`\\(,[^{}]*\\)?}" post) ; followed by , ... }
+           (goto-char beg)
+           (looking-at (concat "[[:space:]]*\\([" keych "]+?\\)[[:space:]]*[,}]"))
+           (cons (match-string-no-properties 1)
+                 (cons (match-beginning 1) (match-end 1)))))))
+
+;;;###autoload
+(defun citar-latex-citation-at-point ()
+  "Find citation macro at point and extract keys.
+Finds brace-delimited strings inside the bounds of the macro,
+splits them at comma characters, and trims whitespace.
+Returns (KEYS . BOUNDS), where KEYS is a list of the found
+citation keys and BOUNDS is a pair of buffer positions indicating
+the start and end of the citation macro."
+  (save-excursion
+    (when-let ((bounds (citar-latex--macro-bounds)))
+      (let ((keylists nil))
+        (goto-char (car bounds))
+        (while (re-search-forward "{\\([^{}]*\\)}" (cdr bounds) 'noerror)
+          (push (split-string (match-string-no-properties 1) "," t "[[:space:]]*")
+                keylists))
+        (cons (apply #'append (nreverse keylists))
+              bounds)))))
 
 (defvar citar-latex-cite-command-history nil
   "Variable for history of cite commands.")

--- a/citar-latex.el
+++ b/citar-latex.el
@@ -150,7 +150,7 @@ inserted."
         (TeX-parse-macro macro
                          (when citar-latex-prompt-for-extra-arguments
                            (cdr (citar-latex-is-a-cite-command macro))))))
-    (citar-latex-insert-keys keys)
+    (citar--insert-keys-comma-separated keys)
     (skip-chars-forward "^}") (forward-char 1)))
 
 (defun citar-latex-is-a-cite-command (command)

--- a/citar-latex.el
+++ b/citar-latex.el
@@ -34,7 +34,7 @@
 (defvar citar-major-mode-functions)
 
 (defcustom citar-latex-cite-commands
-  '((("cite" "Cite" "citet" "Citet" "parencite"
+  '((("cite" "Cite" "citet" "Citet" "citep" "Citep" "parencite"
       "Parencite" "footcite" "footcitetext" "textcite" "Textcite"
       "smartcite" "Smartcite" "cite*" "parencite*" "autocite"
       "Autocite" "autocite*" "Autocite*" "citeauthor" "Citeauthor"
@@ -65,13 +65,13 @@ the point."
   (ignore-errors (reftex-get-bibfile-list)))
 
 (defun citar-latex--macro-bounds ()
-  "Returns the bounds of the citation macro at point.
+  "Return the bounds of the citation macro at point.
 Returns a pair of buffer positions indicating the beginning and
 end of the enclosing citation macro, or nil if point is not
 inside a citation macro.  Moves point to the beginning of the
 macro."
   (unless (fboundp 'TeX-find-macro-boundaries)
-    (error "Please install AUCTeX."))
+    (error "Please install AUCTeX"))
   (save-excursion
     (when-let* ((bounds (TeX-find-macro-boundaries))
                 (macro (progn (goto-char (car bounds))
@@ -83,9 +83,10 @@ macro."
 
 ;;;###autoload
 (defun citar-latex-key-at-point ()
-  "Returns (KEY . BOUNDS), where KEY is the citation key at point
-and BOUNDS is a pair of buffer positions.  Returns nil if there
-is no key at point."
+  "Return citation key at point with its bounds.
+The return value is (KEY . BOUNDS), where KEY is the citation key
+at point and BOUNDS is a pair of buffer positions.  Returns nil
+if there is no key at point."
   (save-excursion
     (when-let* ((bounds (citar-latex--macro-bounds))
                 (keych "^,{}")
@@ -153,10 +154,17 @@ inserted."
     (citar--insert-keys-comma-separated keys)
     (skip-chars-forward "^}") (forward-char 1)))
 
+;;;###autoload
+(defun citar-latex-insert-edit (&optional arg)
+  "Prompt for keys and call `citar-latex-insert-citation.
+With ARG non-nil, rebuild the cache before offering candidates."
+  (citar-latex-insert-citation
+   (citar--extract-keys (citar-select-refs :rebuild-cache arg))))
+
 (defun citar-latex-is-a-cite-command (command)
   "Return element of `citar-latex-cite-commands` containing COMMAND."
   (seq-find (lambda (x) (member command (car x)))
-                 citar-latex-cite-commands))
+            citar-latex-cite-commands))
 
 (provide 'citar-latex)
 ;;; citar-latex.el ends here

--- a/citar-org.el
+++ b/citar-org.el
@@ -84,17 +84,6 @@ Each function takes one argument, a citation."
 
 ;;; Keymaps
 
-(defvar citar-org-map
-  (let ((map (make-sparse-keymap)))
-    (define-key map (kbd "o") (cons "open source (file or link)" #'citar-open))
-    (define-key map (kbd "e") (cons "open bibtex entry" #'citar-open-entry))
-    (define-key map (kbd "f") (cons "open source file" #'citar-open-library-files))
-    (define-key map (kbd "l") (cons "open source link" #'citar-open-link))
-    (define-key map (kbd "n") (cons "open notes" #'citar-open-notes))
-    (define-key map (kbd "r") (cons "refresh" #'citar-refresh))
-    map)
-  "Keymap for org-cite Embark minibuffer functionality.")
-
 (defvar citar-org-citation-map
   (let ((map (make-sparse-keymap)))
     (define-key map (kbd "<mouse-1>") (cons "default action" #'org-open-at-point))

--- a/citar-org.el
+++ b/citar-org.el
@@ -185,6 +185,12 @@ With PROC list, limit to specific processor(s)."
                     (mapconcat (lambda (key) (concat "@" key)) keys "; ")))))
 
 ;;;###autoload
+(defun citar-org-edit-citation (&optional arg)
+  (interactive "P")
+  (let ((org-cite-insert-processor 'citar))
+    (org-cite-insert arg)))
+
+;;;###autoload
 (defun citar-org-follow (_datum _arg)
   "Follow processor for org-cite."
   (call-interactively citar-at-point-function))

--- a/citar-org.el
+++ b/citar-org.el
@@ -159,13 +159,11 @@ With PROC list, limit to specific processor(s)."
 ;; NOTE I may move some or all of these to a separate project
 
 ;;;###autoload
-(defun citar-org-insert (&optional multiple)
+(defun citar-org-select-key (&optional multiple)
   "Return a list of keys when MULTIPLE, or else a key string."
-  (let ((references (citar--extract-keys
-                     (citar-select-refs))))
-    (if multiple
-        references
-      (car references))))
+  (if multiple
+      (citar--extract-keys (citar-select-refs))
+    (car (citar-select-ref))))
 
 (defun citar-org-cite-insert (&rest _args)
   "Wrapper for 'org-cite-insert'."
@@ -397,7 +395,7 @@ Argument CITATION is an org-element holding the references."
 (with-eval-after-load 'oc
   (org-cite-register-processor 'citar
     :insert (org-cite-make-insert-processor
-             #'citar-org-insert
+             #'citar-org-select-key
              #'citar-org-select-style)
     :follow #'citar-org-follow
     :activate #'citar-org-activate))

--- a/citar-org.el
+++ b/citar-org.el
@@ -276,22 +276,20 @@ strings by style."
 
 ;;; Embark target finder
 
-(defun citar-org-citation-finder ()
-  "Return org-cite citation keys at point as a list for `embark'."
-  (when-let ((citation (and (derived-mode-p 'org-mode)
-                            (citar-org--citation-at-point))))
-    `(oc-citation ,(citar--stringify-keys (org-cite-get-references citation t))
-                  . ,(org-cite-boundaries citation))))
-
-(defun citar-org-keys-at-point ()
+;;;###autoload
+(defun citar-org-key-at-point ()
   "Return key at point for org-cite citation-reference."
-  (when-let ((elt (org-element-context)))
-    (pcase (org-element-type elt)
-      ('citation-reference
-       (org-element-property :key elt))
-      ('citation
-       (org-cite-get-references elt t)))))
+  (when-let ((reference (citar-org--reference-at-point)))
+    (cons (org-element-property :key reference)
+          (cons (org-element-property :begin reference)
+                (org-element-property :end reference)))))
 
+;;;###autoload
+(defun citar-org-citation-at-point ()
+  "Return org-cite citation keys at point as a list for `embark'."
+  (when-let ((citation (citar-org--citation-at-point)))
+    (cons (org-cite-get-references citation t)
+          (org-cite-boundaries citation))))
 
 ;;; Functions for editing/modifying citations
 
@@ -400,15 +398,6 @@ strings by style."
           (org-element-interpret-data
            `(citation-reference
              (:key ,key :prefix ,pre :suffix ,post))))))
-
-;; Embark configuration for org-cite
-
-(with-eval-after-load 'embark
-  ;; (set-keymap-parent citar-org-map embark-general-map)
-  (add-to-list 'embark-target-finders 'citar-org-citation-finder)
-  (add-to-list 'embark-keymap-alist '(citar-reference . citar-org-map))
-  (add-to-list 'embark-keymap-alist '(oc-citation . citar-buffer-map))
-  (add-to-list 'embark-pre-action-hooks '(org-cite-insert embark--ignore-target)))
 
 ;; Load this last.
 

--- a/citar.el
+++ b/citar.el
@@ -354,19 +354,22 @@ offering the selection candidates."
          ((string= extension (or "org" "md")) "Notes")
           (t "Library Files")))))
 
-(defun citar--get-major-mode-function (key)
+(defun citar--get-major-mode-function (key &optional default)
   "Return KEY from 'major-mode-functions'."
   (alist-get
    key
-   (cdr
-    (seq-find
-     (lambda (x) (or (eq x t) (apply #'derived-mode-p (car x))))
-     citar-major-mode-functions))))
+   (cdr (seq-find
+         (lambda (modefns)
+           (let ((modes (car modefns)))
+             (or (eq t modes)
+                 (apply #'derived-mode-p (if (listp modes) modes (list modes))))))
+         citar-major-mode-functions))
+   default))
 
 (defun citar--major-mode-function (key default &rest args)
   "Function for the major mode corresponding to KEY applied to ARGS.
 If no function is found, the DEFAULT function is called."
-  (apply (citar--get-major-mode-function key) default args))
+  (apply (citar--get-major-mode-function key default) args))
 
 (defun citar--local-files-to-cache ()
   "The local bibliographic files not included in the global bibliography."

--- a/citar.el
+++ b/citar.el
@@ -189,14 +189,16 @@ If you use 'org-roam' and 'org-roam-bibtex', you can use
   '(((org-mode) .
      ((local-bib-files . citar-org-local-bib-files)
       (insert-citation . citar-org-insert-citation)
-      (keys-at-point . citar-org-keys-at-point)))
+      (key-at-point . citar-org-key-at-point)
+      (citation-at-point . citar-org-citation-at-point)))
     ((latex-mode) .
      ((local-bib-files . citar-latex-local-bib-files)
       (insert-citation . citar-latex-insert-citation)
-      (keys-at-point . citar-latex-keys-at-point)))
+      (key-at-point . citar-latex-key-at-point)
+      (citation-at-point . citar-latex-citation-at-point)))
     ((markdown-mode) .
      ((insert-keys . citar-markdown-insert-keys)
-      (keys-at-point . citar-markdown-key-at-point)
+      (key-at-point . citar-markdown-key-at-point)
       (insert-citation . citar-markdown-insert-citation)))
     (t .
      ((insert-keys . citar--insert-keys-comma-separated))))
@@ -676,11 +678,18 @@ FORMAT-STRING."
 ;;; At-point functions for Embark
 
 ;;;###autoload
-(defun citar-keys-at-point ()
-  "Return the keys of the entry at point."
-  (when-let (keys (and (not (minibufferp))
-                       (citar--major-mode-function 'keys-at-point #'ignore)))
-    (cons 'citation-key (citar--stringify-keys keys))))
+(defun citar-key-finder ()
+  "Return the citation key at point."
+  (when-let (key (and (not (minibufferp))
+                      (citar--major-mode-function 'key-at-point #'ignore)))
+    (cons 'citar-key key)))
+
+;;;###autoload
+(defun citar-citation-finder ()
+  "Return the keys of the citation at point."
+  (when-let (citation (and (not (minibufferp))
+                           (citar--major-mode-function 'citation-at-point #'ignore)))
+    `(citar-citation ,(citar--stringify-keys (car citation)) . ,(cdr citation))))
 
 (defun citar--stringify-keys (keys)
   "Return a list of KEYS as a crm-string for `embark'."
@@ -688,7 +697,9 @@ FORMAT-STRING."
 
 ;;;###autoload
 (with-eval-after-load 'embark
-  (add-to-list 'embark-target-finders 'citar-keys-at-point))
+  (add-to-list 'embark-target-finders 'citar-citation-finder)
+  (add-to-list 'embark-target-finders 'citar-key-finder))
+
 
 (with-eval-after-load 'embark
   (add-to-list 'embark-keymap-alist '(citar-reference . citar-map))

--- a/citar.el
+++ b/citar.el
@@ -188,7 +188,7 @@ If you use 'org-roam' and 'org-roam-bibtex', you can use
 (defcustom citar-major-mode-functions
   '(((org-mode) .
      ((local-bib-files . citar-org-local-bib-files)
-      (insert-citation . citar-org-cite-insert)
+      (insert-citation . citar-org-insert-citation)
       (keys-at-point . citar-org-keys-at-point)))
     ((latex-mode) .
      ((local-bib-files . citar-latex-local-bib-files)

--- a/citar.el
+++ b/citar.el
@@ -192,13 +192,14 @@ If you use 'org-roam' and 'org-roam-bibtex', you can use
       (keys-at-point . citar-org-keys-at-point)))
     ((latex-mode) .
      ((local-bib-files . citar-latex-local-bib-files)
-      (insert-keys . citar-latex-insert-keys)
       (insert-citation . citar-latex-insert-citation)
       (keys-at-point . citar-latex-keys-at-point)))
     ((markdown-mode) .
      ((insert-keys . citar-markdown-insert-keys)
       (keys-at-point . citar-markdown-key-at-point)
-      (insert-citation . citar-markdown-insert-citation))))
+      (insert-citation . citar-markdown-insert-citation)))
+    (t .
+     ((insert-keys . citar--insert-keys-comma-separated))))
   "The variable determining the major mode specifc functionality.
 
 It is alist with keys being a list of major modes.
@@ -849,9 +850,12 @@ With prefix, rebuild the cache before offering candidates."
                       :rebuild-cache current-prefix-arg)))
   (citar--major-mode-function
    'insert-keys
-   (lambda (&rest _)
-     (message "Key insertion is not supported for %s" major-mode))
+   #'citar--insert-keys-comma-separated
    (citar--extract-keys keys-entries)))
+
+(defun citar--insert-keys-comma-separated (keys)
+  "Insert comma separated KEYS."
+  (insert (string-join keys ", ")))
 
 ;;;###autoload
 (defun citar-add-pdf-attachment (keys-entries)


### PR DESCRIPTION
- Context-aware insert-citation
  - [x] Org mode (#383)
  - [x] Latex (already implemented)
  - [ ] Markdown
- Context-aware insert/edit function
  - [x] Org mode (calls `org-cite-insert`)
  - [x] Latex (calls `citar-latex-insert-citation`)
  - [ ] Markdown
- Target finders for keys and citations
  - [x] Org mode
  - [x] Latex
  - [ ] Markdown (based on #395)
- [x] Remove Org-specific Embark target (#381)
- [ ] Update documentation