### PR TITLE
Use thing-at-point for citar-markdown-key-at-point

### DIFF
--- a/citar-markdown.el
+++ b/citar-markdown.el
@@ -64,17 +64,12 @@
 ;;;###autoload
 (defun citar-markdown-key-at-point ()
   "Return a citation key at point for pandoc markdown citations."
-  (save-excursion
-    (let* ((beg (progn
-                  (skip-chars-backward
-                   citar-markdown-regex-citation-key)
-                  (point)))
-           (end (progn
-                  (skip-chars-forward
-                   citar-markdown-regex-citation-key)
-                  (point)))
-           (str (buffer-substring-no-properties beg end)))
-      (cadr (split-string str "[@;]")))))
+  (interactive)
+  (when (thing-at-point-looking-at citar-markdown-regex-citation-key)
+    (let ((stab (copy-syntax-table)))
+      (with-syntax-table stab
+        (modify-syntax-entry ?@ "_")
+        (cadr (split-string (thing-at-point 'symbol) "[]@;]"))))))
 
 (provide 'citar-markdown)
 ;;; citar-markdown.el ends here


### PR DESCRIPTION
This commit aims to fix a problem with the current version of `citar-markdown-key-at-point`, which is that it returns the closing bracket with the last citekey of a given markdown citation, such that `[@Smith2012]` returns `Smith2012]` in the Embark indicator.

Before resorting to `thing-at-point`, I tried editing the `split-string` regex in final line of the current code, to include a closing bracket, like so: `(cadr (split-string str "[]@;]")))))`. This nicely trimmed the closing bracket from the returned string.

But for reasons I don't understand, that change wreaked some strange havoc, leading Embark to recognize anything between brackets as a markdown citation. Not a great outcome.

I had some tinker experience with `thing-at-point`, so voila, an attempt at a bugfix. Interested to know what you think. _Surely_ there's a simpler solution.

In any case, thanks for a great package. Using it daily and enjoying tracking its development, learning a lot from the conversations here between you and others.