### PR TITLE
Add support for finding files with expanded naming convention

### DIFF
--- a/citar-file.el
+++ b/citar-file.el
@@ -112,12 +112,15 @@ Example: ':/path/to/test.pdf:PDF'."
              (extension)
              (seq-map
               (lambda (directory)
-                (expand-file-name
-                 (concat key "." extension) directory))
+                (directory-files directory t
+                                         (s-concat "^" (regexp-quote key)
+                                                   ".*\\("
+                                                   extension
+                                                   "\\)$")))
               dirs)))
-    (let* ((results-key (seq-mapcat
-                         #'possible-file-names-with-extension
-                         extensions))
+    (let* ((results-key (apply #'append (seq-mapcat
+                                         #'possible-file-names-with-extension
+                                         extensions)))
            (file-field (citar-get-value
                         citar-file-variable entry))
            (results-file

--- a/citar.el
+++ b/citar.el
@@ -453,7 +453,8 @@ key associated with each one."
          (star-width (- (frame-width) (+ 2 symbols-width main-width suffix-width))))
     (maphash
      (lambda (citekey entry)
-       (let* ((files
+       (let* ((citar-file-find-additional-files nil)
+              (files
                (when (citar-file--files-for-entry
                       citekey
                       entry


### PR DESCRIPTION
Partial implementation* of the `bibtex-completion-find-additional-pdfs` feature, from `bibtex-completion`.

Allows `citar-file` functions to find files that begin with a citekey and end with an extension listed in `citar-file-extensions`, with any amount (or kind) of text between.

Example: Citar currently finds only "Smith2012.pdf"; with this commit it will also find "Smith2012 - John Smith - Title of Example Book, Vol. 1 (2012).pdf."

*I say "partial implementation" because in `bibtex-completion` this feature is enabled by setting a defcustom to 't'. That's certainly an option, if desirable.
