### PR TITLE
fix(file): remove filter on possible-names

### DIFF
--- a/citar-file.el
+++ b/citar-file.el
@@ -132,11 +132,9 @@ Example: ':/path/to/test.pdf:PDF'."
                          (lambda (dir)
                            (if filematch
                                (directory-files dir t filematch)
-                             (seq-filter
-                              #'file-exists-p
-                              (seq-map (lambda (ext)
-                                         (expand-file-name (concat key "." ext) dir))
-                                       extensions))))
+                             (seq-map (lambda (ext)
+                                        (expand-file-name (concat key "." ext) dir))
+                                      extensions)))
                          dirs))
            (file-field (citar-get-value
                         citar-file-variable entry))

--- a/citar-org.el
+++ b/citar-org.el
@@ -237,6 +237,7 @@ strings by style."
 
 ;;; Org note function
 
+;;;###autoload
 (defun citar-org-open-notes-default (key entry)
   "Open a note file from KEY and ENTRY."
   (if-let* ((file
@@ -385,8 +386,8 @@ strings by style."
 ;; Embark configuration for org-cite
 
 (with-eval-after-load 'embark
-  (set-keymap-parent citar-org-map embark-general-map)
-  (set-keymap-parent citar-org-buffer-map embark-general-map)
+;  (set-keymap-parent citar-org-map embark-general-map)
+;  (set-keymap-parent citar-org-buffer-map embark-general-map)
   (add-to-list 'embark-target-finders 'citar-org-citation-finder)
   (add-to-list 'embark-keymap-alist '(bib-reference . citar-org-map))
   (add-to-list 'embark-keymap-alist '(oc-citation . citar-org-buffer-map))


### PR DESCRIPTION
Fix #412.

Also, autoload citar-org-open-notes-default.

-----
@roshanshariff @localauthor - can you two confirm this change is fine?

Basically, the function change (suggested by @roshanshariff?) filtered the list of possible names to ensure the files were present, which is not the purpose of it (checking if a file is present should happen elsewhere). 

So I simply removed the filter.

But I don't now how this will interact with the new extended search functionality. Will this cause a problem with open-notes, for example, when creating a new note?

EDIT: seems not:

```elisp
ELISP> (let ((citar-file-find-additional-files nil))(citar-file--get-note-filename "t1" citar-notes-paths '("org")))
(("/home/bruce/org/roam/biblio/t1.org" . new))

ELISP> (let ((citar-file-find-additional-files t))(citar-file--get-note-filename "t1" citar-notes-paths '("org")))
(("/home/bruce/org/roam/biblio/t1.org" . new))
```