### PR TITLE
Context-sensitive insertion and edit commands

### DIFF
--- a/README.org
+++ b/README.org
@@ -122,8 +122,10 @@ Such adapters can provide the following capabilities, which one can configure wi
 
 1. ~insert-keys~: to insert citation keys (this may go away though)
 2. ~insert-citation~: to insert citations
-3. ~local-bib-files~: to find bibliographic files associated with a buffer
-4. ~keys-at-point~: returns a list of citekeys at point
+3. ~insert-edit~: to insert citations or edit at point
+4. ~local-bib-files~: to find bibliographic files associated with a buffer
+5. ~key-at-point~: returns the citation key at point
+6. ~citation-at-point~: returns the list of keys in the citation at point
 
 Citar currently includes the following such adapters:
 

--- a/citar-latex.el
+++ b/citar-latex.el
@@ -72,11 +72,6 @@ the point."
   (when (citar-latex-is-a-cite-command (TeX-current-macro))
     (split-string (thing-at-point 'list t) "," t "[{} ]+")))
 
-;;;###autoload
-(defun citar-latex-insert-keys (keys)
-  "Insert comma sperated KEYS in a latex buffer."
-  (insert (string-join keys ", ")))
-
 (defvar citar-latex-cite-command-history nil
   "Variable for history of cite commands.")
 
@@ -109,7 +104,7 @@ inserted."
         (TeX-parse-macro macro
                          (when citar-latex-prompt-for-extra-arguments
                            (cdr (citar-latex-is-a-cite-command macro))))))
-    (citar-latex-insert-keys keys)
+    (citar--insert-keys-comma-separated keys)
     (skip-chars-forward "^}") (forward-char 1)))
 
 (defun citar-latex-is-a-cite-command (command)

--- a/citar-latex.el
+++ b/citar-latex.el
@@ -153,6 +153,13 @@ inserted."
     (citar--insert-keys-comma-separated keys)
     (skip-chars-forward "^}") (forward-char 1)))
 
+;;;###autoload
+(defun citar-latex-insert-edit (&optional arg)
+  "Prompt for keys and call `citar-latex-insert-citation.
+With ARG non-nil, rebuild the cache before offering candidates."
+  (citar-latex-insert-citation
+   (citar--extract-keys (citar-select-refs :rebuild-cache arg))))
+
 (defun citar-latex-is-a-cite-command (command)
   "Return element of `citar-latex-cite-commands` containing COMMAND."
   (seq-find (lambda (x) (member command (car x)))

--- a/citar-latex.el
+++ b/citar-latex.el
@@ -67,9 +67,11 @@ the point."
 ;;;###autoload
 (defun citar-latex-key-at-point ()
   "Return citation key at point with its bounds.
+  
 The return value is (KEY . BOUNDS), where KEY is the citation key
-at point and BOUNDS is a pair of buffer positions.  Returns nil
-if there is no key at point."
+at point and BOUNDS is a pair of buffer positions.  
+
+Return nil if there is no key at point."
   (save-excursion
     (when-let* ((bounds (citar-latex--macro-bounds))
                 (keych "^,{}")
@@ -87,9 +89,11 @@ if there is no key at point."
 ;;;###autoload
 (defun citar-latex-citation-at-point ()
   "Find citation macro at point and extract keys.
-Finds brace-delimited strings inside the bounds of the macro,
+  
+Find brace-delimited strings inside the bounds of the macro,
 splits them at comma characters, and trims whitespace.
-Returns (KEYS . BOUNDS), where KEYS is a list of the found
+
+Return (KEYS . BOUNDS), where KEYS is a list of the found
 citation keys and BOUNDS is a pair of buffer positions indicating
 the start and end of the citation macro."
   (save-excursion
@@ -104,7 +108,8 @@ the start and end of the citation macro."
 
 (defun citar-latex--macro-bounds ()
   "Return the bounds of the citation macro at point.
-Returns a pair of buffer positions indicating the beginning and
+  
+Return a pair of buffer positions indicating the beginning and
 end of the enclosing citation macro, or nil if point is not
 inside a citation macro."
   (unless (fboundp 'TeX-find-macro-boundaries)

--- a/citar-markdown.el
+++ b/citar-markdown.el
@@ -46,8 +46,11 @@
 ;;;###autoload
 (defun citar-markdown-insert-citation (keys)
   "Insert a pandoc-style citation consisting of KEYS.
+  
 If the point is inside a citation, add new keys after the current
-key.  If point is immediately after the opening \[, add new keys
+key.  
+
+If point is immediately after the opening \[, add new keys
 to the beginning of the citation."
   (let* ((citation (citar-markdown-citation-at-point))
          (keys (if citation (seq-difference keys (car citation)) keys))

--- a/citar-markdown.el
+++ b/citar-markdown.el
@@ -39,7 +39,7 @@
 
 ;;;###autoload
 (defun citar-markdown-insert-keys (keys)
-  "Insert comma sperated KEYS in a markdown buffer."
+  "Insert semicolon-separated and @-prefixed KEYS in a markdown buffer."
   (insert (mapconcat (lambda (k) (concat "@" k)) keys "; ")))
 
 ;;;###autoload

--- a/citar-markdown.el
+++ b/citar-markdown.el
@@ -68,6 +68,13 @@ to the beginning of the citation."
           (skip-chars-forward "^;]" (cddr citation))
           (insert "; " keyconcat))))))
 
+;;;###autoload
+(defun citar-markdown-insert-edit (&optional arg)
+  "Prompt for keys and call `citar-markdown-insert-citation.
+With ARG non-nil, rebuild the cache before offering candidates."
+  (citar-markdown-insert-citation
+   (citar--extract-keys (citar-select-refs :rebuild-cache arg))))
+
 (defconst citar-markdown-citation-key-regexp
   (concat "-?@"                         ; @ preceded by optional -
           "\\(?:"

--- a/citar-org.el
+++ b/citar-org.el
@@ -178,9 +178,12 @@ With PROC list, limit to specific processor(s)."
                    (mapconcat (lambda (key) (concat "@" key)) keys "; ")))
         (user-error "Cannot insert a citation here")))))
 
-(defun citar-org-cite-insert (&rest _args)
-  "Wrapper for 'org-cite-insert'."
-  (org-cite-insert current-prefix-arg))
+;;;###autoload
+(defun citar-org-insert-edit (&optional arg)
+  "Run `org-cite-insert` with citar insert processor.
+ARG is used as the prefix argument."
+  (let ((org-cite-insert-processor 'citar))
+    (org-cite-insert arg)))
 
 ;;;###autoload
 (defun citar-org-follow (_datum _arg)

--- a/citar-org.el
+++ b/citar-org.el
@@ -160,13 +160,11 @@ With PROC list, limit to specific processor(s)."
 ;; NOTE I may move some or all of these to a separate project
 
 ;;;###autoload
-(defun citar-org-insert (&optional multiple)
+(defun citar-org-select-key (&optional multiple)
   "Return a list of keys when MULTIPLE, or else a key string."
-  (let ((references (citar--extract-keys
-                     (citar-select-refs))))
-    (if multiple
-        references
-      (car references))))
+  (if multiple
+      (citar--extract-keys (citar-select-refs))
+    (car (citar-select-ref))))
 
 (defun citar-org-cite-insert (&rest _args)
   "Wrapper for 'org-cite-insert'."
@@ -399,7 +397,7 @@ Argument CITATION is an org-element holding the references."
 (with-eval-after-load 'oc
   (org-cite-register-processor 'citar
     :insert (org-cite-make-insert-processor
-             #'citar-org-insert
+             #'citar-org-select-key
              #'citar-org-select-style)
     :follow #'citar-org-follow
     :activate #'citar-org-activate))

--- a/citar.el
+++ b/citar.el
@@ -258,10 +258,10 @@ start and end of the citation."
 
 (defvar citar-map
   (let ((map (make-sparse-keymap)))
-    (define-key map (kbd "b") (cons "insert bibtex" #'citar-insert-bibtex))
     (define-key map (kbd "c") (cons "insert citation" #'citar-insert-citation))
-    (define-key map (kbd "k") (cons "insert key" #'citar-insert-keys))
+    (define-key map (kbd "k") (cons "insert keys" #'citar-insert-keys))
     (define-key map (kbd "fr") (cons "insert formatted reference" #'citar-insert-reference))
+    (define-key map (kbd "b") (cons "insert bibtex" #'citar-insert-bibtex))
     (define-key map (kbd "o") (cons "open source document" #'citar-open))
     (define-key map (kbd "e") (cons "open bibtex entry" #'citar-open-entry))
     (define-key map (kbd "l") (cons "open source URL or DOI" #'citar-open-link))
@@ -277,6 +277,7 @@ start and end of the citation."
 (defvar citar-citation-map
   (let ((map (make-sparse-keymap)))
     (define-key map (kbd "i") (cons "insert or edit" #'citar-insert-edit))
+    (define-key map (kbd "c") (cons "insert citation" #'citar-insert-citation))
     (define-key map (kbd "o") (cons "open source document" #'citar-open))
     (define-key map (kbd "e") (cons "open bibtex entry" #'citar-open-entry))
     (define-key map (kbd "l") (cons "open source URL or DOI" #'citar-open-link))

--- a/citar.el
+++ b/citar.el
@@ -190,7 +190,7 @@ If you use 'org-roam' and 'org-roam-bibtex', you can use
 (defcustom citar-major-mode-functions
   '(((org-mode) .
      ((local-bib-files . citar-org-local-bib-files)
-      (insert-citation . citar-org-cite-insert)
+      (insert-citation . citar-org-insert-citation)
       (key-at-point . citar-org-key-at-point)
       (citation-at-point . citar-org-citation-at-point)))
     ((latex-mode) .
@@ -220,7 +220,8 @@ insert-keys: the corresponding function should insert the list of keys given
 to as the argument at point in the buffer.
 
 insert-citation: the corresponding function should insert a
-complete citation from a list of keys at point.
+complete citation from a list of keys at point.  If the point is
+in a citation, new keys should be added to the citation.
 
 key-at-point: the corresponding function should return the
 citation key at point or nil if there is none.  The return value
@@ -854,15 +855,11 @@ With prefix, rebuild the cache before offering candidates."
 With prefix, rebuild the cache before offering candidates."
   (interactive (list (citar-select-refs
                       :rebuild-cache current-prefix-arg)))
-  (let* ((function (citar--get-major-mode-function 'insert-candidate))
-         (keys (citar--extract-keys keys-entries)))
-    (if (eq function 'citar-org-cite-insert)
-        (call-interactively 'org-cite-insert)
-      (citar--major-mode-function
-       'insert-citation
-       (lambda (&rest _)
-         (message "Citation insertion is not supported for %s" major-mode))
-       keys))))
+  (citar--major-mode-function
+   'insert-citation
+   (lambda (&rest _)
+     (message "Citation insertion is not supported for %s" major-mode))
+   (citar--extract-keys keys-entries)))
 
 ;;;###autoload
 (defun citar-insert-reference (keys-entries)

--- a/citar.el
+++ b/citar.el
@@ -200,9 +200,9 @@ If you use 'org-roam' and 'org-roam-bibtex', you can use
       (citation-at-point . citar-latex-citation-at-point)))
     ((markdown-mode) .
      ((insert-keys . citar-markdown-insert-keys)
+      (insert-citation . citar-markdown-insert-citation)
       (key-at-point . citar-markdown-key-at-point)
-      (citation-at-point . citar-markdown-citation-at-point)
-      (insert-citation . citar-markdown-insert-citation)))
+      (citation-at-point . citar-markdown-citation-at-point)))
     (t .
        ((insert-keys . citar--insert-keys-comma-separated))))
   "The variable determining the major mode specific functionality.

--- a/citar.el
+++ b/citar.el
@@ -194,14 +194,15 @@ If you use 'org-roam' and 'org-roam-bibtex', you can use
       (keys-at-point . citar-org-keys-at-point)))
     ((latex-mode) .
      ((local-bib-files . citar-latex-local-bib-files)
-      (insert-keys . citar-latex-insert-keys)
       (insert-citation . citar-latex-insert-citation)
       (keys-at-point . citar-latex-keys-at-point)))
     ((markdown-mode) .
      ((insert-keys . citar-markdown-insert-keys)
       (keys-at-point . citar-markdown-key-at-point)
-      (insert-citation . citar-markdown-insert-citation))))
-  "The variable determining the major mode specifc functionality.
+      (insert-citation . citar-markdown-insert-citation)))
+    (t .
+       ((insert-keys . citar--insert-keys-comma-separated))))
+  "The variable determining the major mode specific functionality.
 
 It is alist with keys being a list of major modes.
 
@@ -866,9 +867,12 @@ With prefix, rebuild the cache before offering candidates."
                       :rebuild-cache current-prefix-arg)))
   (citar--major-mode-function
    'insert-keys
-   (lambda (&rest _)
-     (message "Key insertion is not supported for %s" major-mode))
+   #'citar--insert-keys-comma-separated
    (citar--extract-keys keys-entries)))
+
+(defun citar--insert-keys-comma-separated (keys)
+  "Insert comma separated KEYS."
+  (insert (string-join keys ", ")))
 
 ;;;###autoload
 (defun citar-add-pdf-to-library (keys-entries)

--- a/citar.el
+++ b/citar.el
@@ -189,7 +189,8 @@ If you use 'org-roam' and 'org-roam-bibtex', you can use
 
 (defcustom citar-major-mode-functions
   '(((org-mode) .
-     ((local-bib-files . citar-org-local-bibs)
+     ((local-bib-files . citar-org-local-bib-files)
+      (insert-citation . citar-org-cite-insert)
       (keys-at-point . citar-org-keys-at-point)))
     ((latex-mode) .
      ((local-bib-files . citar-latex-local-bib-files)
@@ -290,7 +291,7 @@ offering the selection candidates."
              (if (eq action 'metadata)
                  `(metadata
                    (affixation-function . ,#'citar--affixation)
-                   (category . bib-reference))
+                   (category . citar-reference))
                (complete-with-action action candidates string predicate)))
            nil nil nil
            'citar-history citar-presets nil)))
@@ -322,7 +323,7 @@ offering the selection candidates."
              (if (eq action 'metadata)
                  `(metadata
                    (affixation-function . ,#'citar--affixation)
-                   (category . bib-reference))
+                   (category . citar-reference))
                (complete-with-action action candidates string predicate)))
            nil nil nil
            'citar-history citar-presets nil)))
@@ -355,18 +356,22 @@ offering the selection candidates."
          ((string= extension (or "org" "md")) "Notes")
           (t "Library Files")))))
 
+(defun citar--get-major-mode-function (key &optional default)
+  "Return KEY from 'major-mode-functions'."
+  (alist-get
+   key
+   (cdr (seq-find
+         (lambda (modefns)
+           (let ((modes (car modefns)))
+             (or (eq t modes)
+                 (apply #'derived-mode-p (if (listp modes) modes (list modes))))))
+         citar-major-mode-functions))
+   default))
+
 (defun citar--major-mode-function (key default &rest args)
   "Function for the major mode corresponding to KEY applied to ARGS.
 If no function is found, the DEFAULT function is called."
-  (apply
-   (alist-get
-    key
-    (cdr
-     (seq-find
-      (lambda (x) (or (eq x t) (apply #'derived-mode-p (car x))))
-      citar-major-mode-functions))
-    default)
-   args))
+  (apply (citar--get-major-mode-function key default) args))
 
 (defun citar--local-files-to-cache ()
   "The local bibliographic files not included in the global bibliography."
@@ -688,10 +693,8 @@ FORMAT-STRING."
   (add-to-list 'embark-target-finders 'citar-keys-at-point))
 
 (with-eval-after-load 'embark
-  (set-keymap-parent citar-map embark-general-map)
-  (set-keymap-parent citar-buffer-map embark-general-map)
-  (add-to-list 'embark-keymap-alist '(bib-reference . citar-map))
-  (add-to-list 'embark-keymap-alist '(citation-key . citar-buffer-map)))
+  (add-to-list 'embark-keymap-alist '(citar-reference . citar-map))
+  (add-to-list 'embark-keymap-alist '(citar-key . citar-buffer-map)))
 
 ;;; Commands
 
@@ -830,12 +833,15 @@ With prefix, rebuild the cache before offering candidates."
 With prefix, rebuild the cache before offering candidates."
   (interactive (list (citar-select-refs
                       :rebuild-cache current-prefix-arg)))
-  ;; TODO
-  (citar--major-mode-function
-   'insert-citation
-   (lambda (&rest _)
-     (message "Citation insertion is not supported for %s" major-mode))
-   (citar--extract-keys keys-entries)))
+  (let* ((function (citar--get-major-mode-function 'insert-candidate))
+         (keys (citar--extract-keys keys-entries)))
+    (if (eq function 'citar-org-cite-insert)
+        (call-interactively 'org-cite-insert)
+      (citar--major-mode-function
+       'insert-citation
+       (lambda (&rest _)
+         (message "Citation insertion is not supported for %s" major-mode))
+       keys))))
 
 ;;;###autoload
 (defun citar-insert-reference (keys-entries)


### PR DESCRIPTION
This is a continuation of #394.

- Context-aware insert-citation
  - [x] Org mode
  - [x] Latex (already implemented)
  - [x] Markdown
- Context-aware insert/edit function
  - [x] Org mode (calls `org-cite-insert`)
  - [x] Latex (calls `citar-latex-insert-citation`)
  - [x] Markdown (calls `citar-markdown-insert-citation`)
- Target finders for keys and citations
  - [x] Org mode
  - [x] Latex
  - [x] Markdown (based on #395)
- [x] Remove Org-specific Embark target (#381)
- [x] Update documentation

Partly implements #383: in Markdown, `citar-insert-citation` will now add new keys after the current citation key, or at the beginning of the citation if point is just after `[`.

Fixes #278, fixes #393: `citar-insert-citation` now does something useful in Org mode, either inserting a new org-cite citation or adding new keys to an existing citation at point. The new keys are added at the beginning of the citation if point is before the first key, or after the current key otherwise.

Relevant to #203: there are now two target finders, one for individual keys and the other for full citations. Both target types have the same keymap, offering the usual open actions. Running `embark-act` once will select and highlight the single key at point, and then running `embark-cycle` (or pressing the key bound to `embark-act` again) will select and highlight the entire citation. Depending on which target is active, the open commands will either act on a single key or all the keys in the citation.

Relevant to #190: the new `citar-insert-edit` action now runs the `insert-edit` major mode function, which is currently a thin wrapper around `org-cite-insert` in Org mode. TBD whether this behaviour should be changed.

Fixes #387.