### PR TITLE
Minor edits

### DIFF
--- a/citar-filenotify.el
+++ b/citar-filenotify.el
@@ -76,7 +76,7 @@ The callback is called without it when
 If it is other than 'global or 'local invalidate both"
   (unless (eq 'local scope)
     (setq citar--candidates-cache 'uninitialized))
-  (unless (eq 'glocal scope)
+  (unless (eq 'global scope)
     (setq citar--local-candidates-cache 'uninitialized)))
 
 (defun citar-filenotify--make-default-callback (func scope &optional change)

--- a/citar.el
+++ b/citar.el
@@ -741,7 +741,7 @@ FORMAT-STRING."
          (citar-file--files-for-multiple-entries
           keys-entries
           (append citar-library-paths citar-notes-paths)
-          citar-file-extensions))
+          (append citar-file-extensions citar-file-note-extensions)))
          (links
           (seq-map
            (lambda (key-entry)

--- a/citar.el
+++ b/citar.el
@@ -760,7 +760,7 @@ FORMAT-STRING."
 
 (defun citar--library-files-action (keys-entries action)
   "Run ACTION on files associated with KEYS-ENTRIES."
-  (let ((fn (pcase action
+  (if-let ((fn (pcase action
               ('open 'citar-file-open)
               ('attach 'mml-attach-file)))
         (files
@@ -775,7 +775,8 @@ FORMAT-STRING."
           (dolist (file selected-files)
             (funcall fn file)))
       (dolist (file files)
-        (funcall fn file)))))
+        (funcall fn file)))
+    (message "No associated file")))
 
 ;;;###autoload
 (defun citar-open-library-files (keys-entries)


### PR DESCRIPTION
Combining these commits, for convenience.

The first two seem uncontroversial: remove a duplicate function and include `citar-file-note-extensions` in `citar-open`. 

The third and fourth might be handled differently:

The third adds a "No associated file" message to `citar--library-files-action`, for cases where there is no associated file.

The fourth adds a "Key not found" message to `citar-select-ref/s`, which is returned if one of the many citar-open functions (open, library-files, notes, link, entry) is invoked at-point on a key that is malformed or simply not in the bibliography. Currently in this case these functions return an unhelpful error ("Wrong type argument: stringp, nil") because `citar-select-refs` has passed them `nil`.
