### PR TITLE
refactor major-mode-functions to use cl-defstruct

### DIFF
--- a/citar-org.el
+++ b/citar-org.el
@@ -438,5 +438,12 @@ Argument CITATION is an org-element holding the references."
     :follow #'citar-org-follow
     :activate #'citar-org-activate))
 
+(citar-register-adapter 'org
+  :local-bib-files #'citar-org-local-bib-files
+  :insert-citation #'citar-org-insert-citation
+  :insert-edit #'citar-org-insert-edit
+  :key-at-point #'citar-org-key-at-point
+  :citation-at-point #'citar-org-citation-at-point)
+
 (provide 'citar-org)
 ;;; citar-org.el ends here


### PR DESCRIPTION
This is the start of an implementation of #450.

You can see what the impact would be by looking at the org example changes here.

Any feedback on this direction @oatmealm @localauthor @roshanshariff?

Would this be more elegant and clear?

I think if the `citar-register-adapter` blocks are autoloaded the functionality should be the same?

OTOH, might just be overkill, since it's not new adapters aren't likely common.