### PR TITLE
Refactor reference functions, add citar-copy-reference, citar-citeproc

### DIFF
--- a/citar-citeproc.el
+++ b/citar-citeproc.el
@@ -68,7 +68,7 @@
   "Select CSL style to be used with 'citar-citeproc-format-reference'."
   (interactive)
   (unless citar-citeproc-csl-styles-dir
-    (error "Be sure to set 'cite-citeproc-csl-styles-dir' to your CSL styles directory"))
+    (error "Be sure to set 'citar-citeproc-csl-styles-dir' to your CSL styles directory"))
   (let* ((files (directory-files citar-citeproc-csl-styles-dir t "csl"))
          (list (mapcar
                 (lambda (file)
@@ -87,7 +87,7 @@ With prefix-argument, select CSL style."
             current-prefix-arg)
     (citar-citeproc-select-csl-style))
   (unless citar-citeproc-csl-locales-dir
-    (error "Be sure to set 'cite-citeproc-csl-locales-dir' to your CSL locales directory"))
+    (error "Be sure to set 'citar-citeproc-csl-locales-dir' to your CSL locales directory"))
   (let* ((itemids (mapcar (lambda (x) (car x)) keys-entries))
          (proc (citeproc-create citar-citeproc-csl-style
 			        (citeproc-hash-itemgetter-from-any citar-bibliography)

--- a/citar-citeproc.el
+++ b/citar-citeproc.el
@@ -21,7 +21,7 @@
 ;;  CSL styles, using 'citeproc-el'.
 
 ;;  To use: load this file, set the required directory paths
-;;  'citar-citeproc-csl-locales-dir' and 'citar-citeproc-csl-styles-dir', set
+;;  'citar-citeproc-csl-locales-dir' and 'citar-citeproc-csl-style-dirs', set
 ;;  'citar-format-reference-function' to 'citar-citeproc-format-reference',
 ;;  and call one of the general reference functions, either
 ;;  'citar-insert-reference' or 'citar-copy-reference'.
@@ -29,7 +29,7 @@
 ;;  To set a CSL style, either set 'cite-citeproc-csl-style' manually to the
 ;;  path to the desired CSL style file or call
 ;;  'citar-citeproc-select-csl-style' to choose from a style file located in
-;;  'citar-citeproc-csl-style-dir'.
+;;  'citar-citeproc-csl-style-dirs'.
 
 ;;  If a CSL style is not set before running 'citar-citeproc-format-reference',
 ;;  the user will be prompted to set a style.
@@ -42,10 +42,10 @@
 (require 'citar)
 (require 'citeproc-el)
 
-(defcustom citar-citeproc-csl-styles-dir nil
-  "Path to CSL styles dir."
+(defcustom citar-citeproc-csl-style-dirs nil
+  "List of CSL style directories."
   :group 'citar
-  :type 'string)
+  :type '(repeat string))
 
 (defcustom citar-citeproc-csl-locales-dir nil
   "Path to CSL locales dir, required for 'citar-citeproc-format-reference'."
@@ -53,13 +53,17 @@
   :type 'string)
 
 (defvar citar-citeproc-csl-style nil
-  "Path to CSL style dir, for use with 'citar-citeproc-format-reference'.")
+  "Path to CSL style file to be used with 'citar-citeproc-format-reference'.")
 
 (defun citar-citeproc-select-csl-style ()
+  "Select CSL style to be used with 'citar-citeproc-format-reference'."
   (interactive)
-  (let* ((list (directory-files citar-citeproc-csl-styles-dir nil "csl"))
-         (style (completing-read "Select CSL style file: " list nil t)))
-    (setq citar-citeproc-csl-style (concat citar-citeproc-csl-styles-dir style))))
+  (let* ((files (delete-dups (apply #'append (mapcar
+                                              (lambda (dir)
+                                                (directory-files dir nil "csl"))
+                                              citar-citeproc-csl-style-dirs))))
+                (style (completing-read "Select CSL style file: " files nil t))))
+    (setq citar-citeproc-csl-style (concat citar-citeproc-csl-style-dirs style)))
 
 (defun citar-citeproc-format-reference (keys-entries)
   "Return formatted reference(s) for KEYS-ENTRIES via 'citeproc-el'.

--- a/citar-citeproc.el
+++ b/citar-citeproc.el
@@ -1,0 +1,83 @@
+;;; citar-citeproc.el --- Citeproc reference support for citar -*- lexical-binding: t; -*-
+;;
+;; This file is not part of GNU Emacs.
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;;  Provides functions for formatting bibliographic references according to
+;;  CSL styles, using 'citeproc-el'.
+
+;;  To use: load this file, set the required directory paths
+;;  'citar-citeproc-csl-locales-dir' and 'citar-citeproc-csl-styles-dir', set
+;;  'citar-format-reference-function' to 'citar-citeproc-format-reference',
+;;  and call one of the general reference functions, either
+;;  'citar-insert-reference' or 'citar-copy-reference'.
+
+;;  To set a CSL style, either set 'cite-citeproc-csl-style' manually to the
+;;  path to the desired CSL style file or call
+;;  'citar-citeproc-select-csl-style' to choose from a style file located in
+;;  'citar-citeproc-csl-style-dir'.
+
+;;  If a CSL style is not set before running 'citar-citeproc-format-reference',
+;;  the user will be prompted to set a style.
+
+;;  A CSL style can also be set by calling 'citar-insert-reference' or
+;;  'citar-copy-reference' with a prefix-argument.
+
+;;; Code:
+
+(require 'citar)
+(require 'citeproc-el)
+
+(defcustom citar-citeproc-csl-styles-dir nil
+  "Path to CSL styles dir."
+  :group 'citar
+  :type 'string)
+
+(defcustom citar-citeproc-csl-locales-dir nil
+  "Path to CSL locales dir, required for 'citar-citeproc-format-reference'."
+  :group 'citar
+  :type 'string)
+
+(defvar citar-citeproc-csl-style nil
+  "Path to CSL style dir, for use with 'citar-citeproc-format-reference'.")
+
+(defun citar-citeproc-select-csl-style ()
+  (interactive)
+  (let* ((list (directory-files citar-citeproc-csl-styles-dir nil "csl"))
+         (style (completing-read "Select CSL style file: " list nil t)))
+    (setq citar-citeproc-csl-style (concat citar-citeproc-csl-styles-dir style))))
+
+(defun citar-citeproc-format-reference (keys-entries)
+  "Return formatted reference(s) for KEYS-ENTRIES via 'citeproc-el'.
+  Formatting follows CSL style set in 'citar-citeproc-csl-style'.
+  With prefix-argument, select CSL style."
+  (when (or (eq citar-citeproc-csl-style nil)
+            current-prefix-arg)
+    (citar-citeproc-select-csl-style))
+  (let* ((itemids (mapcar (lambda (x) (car x)) keys-entries))
+         (proc (citeproc-create citar-citeproc-csl-style
+			        (citeproc-hash-itemgetter-from-any citar-bibliography)
+			        (citeproc-locale-getter-from-dir citar-citeproc-csl-locales-dir)
+			        "en-US"))
+         (references (car (progn
+                            (citeproc-add-uncited itemids proc)
+                            (citeproc-render-bib proc 'plain)
+                            ))))
+    references))
+
+(provide 'citar-citeproc)
+;;; citar-citeproc.el ends here

--- a/citar-citeproc.el
+++ b/citar-citeproc.el
@@ -67,6 +67,8 @@
 (defun citar-citeproc-select-csl-style ()
   "Select CSL style to be used with 'citar-citeproc-format-reference'."
   (interactive)
+  (unless citar-citeproc-csl-styles-dir
+    (error "Be sure to set 'cite-citeproc-csl-styles-dir' to your CSL styles directory"))
   (let* ((files (directory-files citar-citeproc-csl-styles-dir t "csl"))
          (list (mapcar
                 (lambda (file)
@@ -84,6 +86,8 @@ With prefix-argument, select CSL style."
   (when (or (eq citar-citeproc-csl-style nil)
             current-prefix-arg)
     (citar-citeproc-select-csl-style))
+  (unless citar-citeproc-csl-locales-dir
+    (error "Be sure to set 'cite-citeproc-csl-locales-dir' to your CSL locales directory"))
   (let* ((itemids (mapcar (lambda (x) (car x)) keys-entries))
          (proc (citeproc-create citar-citeproc-csl-style
 			        (citeproc-hash-itemgetter-from-any citar-bibliography)

--- a/citar.el
+++ b/citar.el
@@ -939,13 +939,13 @@ With prefix, rebuild the cache before offering candidates."
 (defun citar-insert-reference (keys-entries)
   "Insert formatted reference(s) associated with the KEYS-ENTRIES."
   (interactive (list (citar-select-refs)))
-  (insert (apply citar-format-reference-function (list keys-entries))))
+  (insert (funcall citar-format-reference-function keys-entries)))
 
 ;;;###autoload
 (defun citar-copy-reference (keys-entries)
   "Copy formatted reference(s) associated with the KEYS-ENTRIES."
   (interactive (list (citar-select-refs)))
-  (let ((references (apply citar-format-reference-function (list keys-entries))))
+  (let ((references (funcall citar-format-reference-function keys-entries)))
     (if (not (equal "" references))
         (progn
           (kill-new references)

--- a/citar.el
+++ b/citar.el
@@ -111,16 +111,11 @@ for the title field for new notes."
                    :options (main suffix preview note)))
 
 (defcustom citar-format-reference-function
-  #'citar--format-reference
+  #'citar-format-reference
   "A function that takes a list of (KEY . ENTRY), and returns
 formatted references as a string."
   :group 'citar
   :type 'function)
-
-(defcustom citar-citeproc-csl-style nil
-  "Path to CSL file, required for 'citar-citeproc-format-reference'."
-  :group 'citar
-  :type 'string)
 
 (defcustom citar-display-transform-functions
   ;; TODO change this name, as it might be confusing?
@@ -932,26 +927,22 @@ With prefix, rebuild the cache before offering candidates."
 
 ;;;###autoload
 (defun citar-insert-reference (keys-entries)
-  "Insert formatted reference(s) associated with the KEYS-ENTRIES.
-With prefix, rebuild the cache before offering candidates."
-  (interactive (list (citar-select-refs
-                      :rebuild-cache current-prefix-arg)))
+  "Insert formatted reference(s) associated with the KEYS-ENTRIES."
+  (interactive (list (citar-select-refs)))
   (insert (apply citar-format-reference-function (list keys-entries))))
 
 ;;;###autoload
 (defun citar-copy-reference (keys-entries)
-  "Copy formatted reference(s) associated with the KEYS-ENTRIES.
-With prefix, rebuild the cache before offering candidates."
-  (interactive (list (citar-select-refs
-                      :rebuild-cache current-prefix-arg)))
+  "Copy formatted reference(s) associated with the KEYS-ENTRIES."
+  (interactive (list (citar-select-refs)))
   (let ((references (apply citar-format-reference-function (list keys-entries))))
     (if (not (equal "" references))
         (progn
           (kill-new references)
-          (message (format "Copied:\n  %s" references)))
+          (message (format "Copied:\n%s" references)))
       (message "Key not found."))))
 
-(defun citar--format-reference (keys-entries)
+(defun citar-format-reference (keys-entries)
   "Return formatted reference(s) associated with the KEYS-ENTRIES."
   (let* ((template (citar-get-template 'preview))
          (references
@@ -960,23 +951,6 @@ With prefix, rebuild the cache before offering candidates."
               (when template
                 (insert (citar--format-entry-no-widths (cdr key-entry) template))))
             (buffer-string))))
-    references))
-
-(defun citar-citeproc-format-reference (keys-entries)
-  "Return formatted reference(s) for KEYS-ENTRIES via 'citeproc-el'.
-  Formatting follows CSL style set in 'citar-citeproc-csl-style'.
-  With optional ARG, reference copied to kill-ring."
-  ;; requires citeproc-el; where to ensure requirement?
-  (let* ((itemids (mapcar (lambda (x) (car x)) keys-entries))
-         (proc (citeproc-create citar-citeproc-csl-style
-			        (citeproc-hash-itemgetter-from-any citar-bibliography)
-                                ;; not sure about this method of setting locale-getter
-			        (citeproc-locale-getter-from-dir org-cite-csl-locales-dir)
-			        "en-US"))
-         (references (car (progn
-                               (citeproc-add-uncited itemids proc)
-                               (citeproc-render-bib proc 'plain)
-                               ))))
     references))
 
 ;;;###autoload

--- a/citar.el
+++ b/citar.el
@@ -112,10 +112,20 @@ for the title field for new notes."
 
 (defcustom citar-format-reference-function
   #'citar-format-reference
-  "A function that takes a list of (KEY . ENTRY), and returns
-formatted references as a string."
+  "Function used to render formatted references.
+
+This function is called by 'citar-insert-reference' and
+'citar-copy-reference'. The default value,
+'citar-format-reference', formats references using the 'preview'
+template set in 'citar-template'. To use 'citeproc-el' to format
+references according to CSL styles, set the value to
+'citar-citeproc-format-reference'. Alternatively, set to a custom
+function that takes a list of (KEY . ENTRY) and returns formatted
+references as a string."
   :group 'citar
-  :type 'function)
+  :type '(choice (const :tag "Use 'citar-template'" citar-format-reference)
+                 (const :tag "Use 'citeproc-el'" citar-citeproc-format-reference)
+                 (function :tag "Other")))
 
 (defcustom citar-display-transform-functions
   ;; TODO change this name, as it might be confusing?

--- a/citar.el
+++ b/citar.el
@@ -117,6 +117,11 @@ formatted references as a string."
   :group 'citar
   :type 'function)
 
+(defcustom citar-citeproc-csl-style nil
+  "Path to CSL file, required for 'citar-citeproc-format-reference'."
+  :group 'citar
+  :type 'string)
+
 (defcustom citar-display-transform-functions
   ;; TODO change this name, as it might be confusing?
   '((t  . citar-clean-string)
@@ -955,6 +960,23 @@ With prefix, rebuild the cache before offering candidates."
               (when template
                 (insert (citar--format-entry-no-widths (cdr key-entry) template))))
             (buffer-string))))
+    references))
+
+(defun citar-citeproc-format-reference (keys-entries)
+  "Return formatted reference(s) for KEYS-ENTRIES via 'citeproc-el'.
+  Formatting follows CSL style set in 'citar-citeproc-csl-style'.
+  With optional ARG, reference copied to kill-ring."
+  ;; requires citeproc-el; where to ensure requirement?
+  (let* ((itemids (mapcar (lambda (x) (car x)) keys-entries))
+         (proc (citeproc-create citar-citeproc-csl-style
+			        (citeproc-hash-itemgetter-from-any citar-bibliography)
+                                ;; not sure about this method of setting locale-getter
+			        (citeproc-locale-getter-from-dir org-cite-csl-locales-dir)
+			        "en-US"))
+         (references (car (progn
+                               (citeproc-add-uncited itemids proc)
+                               (citeproc-render-bib proc 'plain)
+                               ))))
     references))
 
 ;;;###autoload


### PR DESCRIPTION
In response to https://github.com/bdarcus/citar/issues/448#issuecomment-981833659 and in light of #245.

This refactors the handling of references to better facilitate the addition of `citar-copy-reference`.

- `citar-insert-reference-function` is now `citar-format-reference-function`

- `citar--insert-reference` is now `citar--format-reference`

The function set in `citar-format-reference-function` must return formatted references as a string, which is either inserted by `citar-insert-reference` or added to the kill-ring by `citar-copy-reference`.

To consider:
- What do you think about the way `citar--format-reference` formats multiple references (ie, no spacing b/t references; refs not sorted)? This is how `citar--insert-reference` worked too, but maybe now is a good time to tweak things, if desired.


Also added here, in its own commit: `citar-citeproc-format-reference`, which requires the `citeproc-el` library.

Some details for consideration:
- When/where to check for, or ensure, that `citeproc-el` is loaded?
- Where should `citar-citeproc` functions/variables be located?
-  The user needs to set the path to the desired CSL file. This is done here with a new defcustom, `citar-citeproc-csl-style`. Thoughts?
- The function needs to point to a csl-locales directory. This is done here by pointing to `org-cite-csl-locales-dir`, because that's what worked with my config. There must be a more general way, but I'm not sure what would be best.



