### PR TITLE
Default citation style

### DIFF
--- a/citar-latex.el
+++ b/citar-latex.el
@@ -170,12 +170,8 @@ inserted."
       (let ((macro
 	     (or command
 		 (if (xor invert-prompt citar-latex-prompt-for-cite-style)
-                     (completing-read "Cite command: "
-                                      (seq-mapcat #'car citar-latex-cite-commands)
-                                      nil nil nil
-                                      'citar-latex-cite-command-history
-				      citar-latex-default-cite-command nil))
-	       citar-latex-default-cite-command)))
+                     (citar-latex-select-command)
+		   citar-latex-default-cite-command))))
         (TeX-parse-macro macro
                          (when citar-latex-prompt-for-extra-arguments
                            (cdr (citar-latex-is-a-cite-command macro))))))
@@ -188,6 +184,14 @@ inserted."
 With ARG non-nil, rebuild the cache before offering candidates."
   (citar-latex-insert-citation
    (citar--extract-keys (citar-select-refs :rebuild-cache arg))))
+
+(defun citar-latex-select-command ()
+  "Complete a citation command for LaTeX."
+  (completing-read "Cite command: "
+                   (seq-mapcat #'car citar-latex-cite-commands)
+                   nil nil nil
+                   'citar-latex-cite-command-history
+		   citar-latex-default-cite-command nil))
 
 (defun citar-latex-is-a-cite-command (command)
   "Return element of `citar-latex-cite-commands` containing COMMAND."

--- a/citar.el
+++ b/citar.el
@@ -896,17 +896,22 @@ With prefix, rebuild the cache before offering candidates."
           (browse-url-default-browser link)
         (message "No link found for %s" key-entry)))))
 
+
 ;;;###autoload
-(defun citar-insert-citation (keys-entries)
+(defun citar-insert-citation (keys-entries &optional arg)
   "Insert citation for the KEYS-ENTRIES.
-With prefix, rebuild the cache before offering candidates."
-  (interactive (list (citar-select-refs
-                      :rebuild-cache current-prefix-arg)))
+
+Prefix ARG is passed to the mode-specific insertion function. It
+should invert the default behaviour for that mode with respect to
+citation styles. See specific functions for more detail."
+  (interactive (list (citar-select-refs) ;; key-entries
+		     current-prefix-arg)) ;; arg
   (citar--major-mode-function
    'insert-citation
    (lambda (&rest _)
      (message "Citation insertion is not supported for %s" major-mode))
-   (citar--extract-keys keys-entries)))
+   (citar--extract-keys keys-entries)
+    arg))
 
 (defun citar-insert-edit (&optional arg)
   "Edit the citation at point."


### PR DESCRIPTION
Here's a draft PR to get started with, fixing #452. I've only implemented LaTeX support so far. Some notes:

Basically what we're doing is having a variable which controls whether to prompt for a citation style, and then the behaviour that variable controls is inverted by a prefix arg. The only entry point is `citar-insert-citation`, so it'll be that commands prefix arg that controls things. There are thus two approaches:
1) have a single variable (e.g. `'citar-prompt-for-cite-style`), do the inversion logic with in `citar-insert-citation`, then pass the result to the specific major mode functions as an argument which tells them whether or not to prompt. They don't need to worry about handling prefix args or doing logic with the variable. This has the advantage that there is only one variable and one piece of logic.
2) have a separate variable for each major mode, pass the prefix arg itself to each major mode function, and let them handle it. This has more going on (and therefore, more to go *wrong*). But it's what I ended up with. The three modes we support are quite different, at least at the moment. LaTeX has good support for prompting for citation styles, org less so, pandoc doesn't *have* citation styles, though it has a binary option to suppress author's names. I decided that trying to handle the logic in `citar-insert-citation` was more generalistic than the functions themselves would support.

For similar reasons, all the variables controlling this behaviour are mode-specific: one for LaTeX, one for markdown etc. Do you think this is a good call, or would you rather a more generalistic approach?

Because these are just variables, they can be set file-/dir-(project-?)locally, so that should satisfy @roshanshariff's idea (though I don't use or know much about local variables, so I haven't actually tested this yet).

I put `invert-prompt` in front of `command` in `citar-latex-insert-citation` because `citar-insert-citation` passes a prefix arg to every major mode function, so the argument which inherits that has to come first. This will apply to the others as well.

I'll have a go at implementing similar things for markdown and org:
- Do you like the idea of using a prefix arg as a switch for suppressing the author in markdown? 
- Would you like me to try to implement initial citaton-style-choice for org mode (like we currently have for latex) and make the behaviour consistent? I would be happy to try, but maybe you think that's beyond the scope of this PR?

(This is a draft because there's so much unfinished. I'll promote to full when it's a bit more tied up)