### PR TITLE
citar-file.el: Refactor file-finding functions

### DIFF
--- a/citar-file.el
+++ b/citar-file.el
@@ -138,7 +138,7 @@ File names are expanded relative to the elements of DIRS."
                   (funcall parser dirs filefield))
                 citar-file-parser-functions)))
 
-(defun citar-file--filename-regexp (keys extensions &optional find-additional)
+(defun citar-file--make-filename-regexp (keys extensions &optional find-additional)
   "Regexp matching file names starting with KEYS and ending with EXTENSIONS.
 See the documentation of `citar-file--directory-files` for the
 meaning of FIND-ADDITIONAL."
@@ -186,7 +186,7 @@ the elements of KEYS and EXTENSIONS, respectively.  It does not
 need to scan the contents of DIRS in this case."
   (let ((files (make-hash-table :test #'equal))
         (filematch (unless (and keys extensions (not find-additional))
-                     (citar-file--filename-regexp keys extensions find-additional))))
+                     (citar-file--make-filename-regexp keys extensions find-additional))))
     (prog1 files
       (dolist (dir dirs)
         (when (file-directory-p dir)
@@ -272,7 +272,9 @@ function that will open a new file if the note is not present."
   (let ((files (citar-file--directory-files dirs (list key) extensions
                                             citar-file-find-additional-files)))
     (or (car (gethash key files))
-        (expand-file-name (concat key "." (car extensions)) (car dirs)))))
+        (when-let ((dir (car dirs))
+                   (ext (car extensions)))
+          (expand-file-name (concat key "." ext) dir)))))
 
 (provide 'citar-file)
 ;;; citar-file.el ends here

--- a/citar-org.el
+++ b/citar-org.el
@@ -275,6 +275,7 @@ With optional argument FORCE, force the creation of a new ID."
     (ignore-errors (citar-org-id-get-create))
     (ignore-errors (org-roam-ref-add (concat "@" key)))))
 
+;;;###autoload
 (defun citar-org-format-note-default (key entry filepath)
   "Format a note FILEPATH from KEY and ENTRY."
     (let* ((template (citar-get-template 'note))

--- a/citar-org.el
+++ b/citar-org.el
@@ -283,18 +283,19 @@ With optional argument FORCE, force the creation of a new ID."
             (when template
               (citar--format-entry-no-widths
                entry
-               template))))
-      (funcall citar-file-open-function filepath)
-      ;; This just overrides other template insertion.
-      (erase-buffer)
-      (citar-org-roam-make-preamble key)
-      (insert "#+title: ")
-      (when template (insert note-meta))
-      (insert "\n\n|\n\n#+print_bibliography:")
-      (search-backward "|")
-      (delete-char 1)
-      (when (boundp 'evil-state)
-        (evil-insert 1))))
+               template)))
+           (buffer (find-file filepath)))
+      (with-current-buffer buffer
+        ;; This just overrides other template insertion.
+        (erase-buffer)
+        (citar-org-roam-make-preamble key)
+        (insert "#+title: ")
+        (when template (insert note-meta))
+        (insert "\n\n|\n\n#+print_bibliography:")
+        (search-backward "|")
+        (delete-char 1)
+        (when (boundp 'evil-state)
+          (evil-insert 1)))))
 
 ;;; Embark target finder
 

--- a/citar-org.el
+++ b/citar-org.el
@@ -283,18 +283,19 @@ With optional argument FORCE, force the creation of a new ID."
             (when template
               (citar--format-entry-no-widths
                entry
-               template))))
-      (funcall citar-file-open-function filepath)
-      ;; This just overrides other template insertion.
-      (erase-buffer)
-      (citar-org-roam-make-preamble key)
-      (insert "#+title: ")
-      (when template (insert note-meta))
-      (insert "\n\n|\n\n#+print_bibliography:")
-      (search-backward "|")
-      (delete-char 1)
-      (when (fboundp 'evil-insert)
-        (evil-insert 1))))
+               template)))
+           (buffer (find-file filepath)))
+      (with-current-buffer buffer
+        ;; This just overrides other template insertion.
+        (erase-buffer)
+        (citar-org-roam-make-preamble key)
+        (insert "#+title: ")
+        (when template (insert note-meta))
+        (insert "\n\n|\n\n#+print_bibliography:")
+        (search-backward "|")
+        (delete-char 1)
+        (when (fboundp 'evil-insert)
+          (evil-insert 1)))))
 
 ;;; Embark target finder
 

--- a/citar.el
+++ b/citar.el
@@ -819,7 +819,7 @@ With prefix, rebuild the cache before offering candidates."
                       :rebuild-cache current-prefix-arg)))
   (when (and (null citar-notes-paths)
              (equal citar-format-note-function
-                    'citar-org-open-notes-default))
+                    'citar-org-format-notes-default))
     (message "You must set 'citar-notes-paths' to open notes with default notes function"))
   (dolist (key-entry keys-entries)
     (funcall citar-open-note-function (car key-entry) (cdr key-entry))))
@@ -830,7 +830,7 @@ With prefix, rebuild the cache before offering candidates."
                                                  citar-notes-paths
                                                  citar-file-note-extensions))
             (file-exists (file-exists-p file)))
-      (funcall citar-file-open-function file)
+      (find-file file)
     (funcall citar-format-note-function key entry file)))
 
 ;;;###autoload

--- a/citar.el
+++ b/citar.el
@@ -55,11 +55,6 @@
 (defvar embark-meta-map)
 (defvar embark-transformer-alist)
 (defvar citar-org-open-note-function)
-(defvar citar-file-extensions)
-(defvar citar-file-note-extensions)
-(defvar citar-file-open-prompt)
-(defvar citar-file-variable)
-(defvar citar-file-find-additional-files)
 
 ;;; Variables
 
@@ -487,11 +482,11 @@ key associated with each one."
           (parsebib-parse bib-files :fields (citar--fields-to-parse)))
          (hasfilep (citar-file--has-file-p citar-library-paths
                                            citar-file-extensions
-                                           citar-file-find-additional-files
+                                           citar-file-additional-files-separator
                                            citar-file-variable))
          (hasnotep (citar-file--has-file-p citar-notes-paths
                                            citar-file-note-extensions
-                                           citar-file-find-additional-files))
+                                           citar-file-additional-files-separator))
          (main-width (citar--format-width (citar-get-template 'main)))
          (suffix-width (citar--format-width (citar-get-template 'suffix)))
          (symbols-width (string-width (citar--symbols-string t t t)))


### PR DESCRIPTION
Implements the changes discussed in #456:

Split the functionality of `citar-file--possible-names` into two new functions:
- `citar-file--parse-file-field` to extract file names from an entry field
- `citar-file--directory-files` to find files in directories whose names start with keys.

Change `citar-file--files-for-entry`, `citar-file--files-for-multiple-entries`, and `citar-file--get-note-filename` to use these functions.

Add the function `citar-file--has-file-p`, which scans the relevant directories once and returns a predicate for the existence of associated files. Use this function in `citar--format-candidates` to efficiently add "has:files" and "has:notes" indicators.

With this implementation, the "has:file" indicator can be incorrect when `citar-file-find-additional-files` is set to `t` or some separator that is present in the citation key. In particular, setting it to t will only find files that don't have extra text after the key, just as if it was set to nil. If it is set to a separator that is present in a citation key, then it can cause false positives or negatives for filenames that contain additional text after the key. These issues only affect the indicator display and don't affect actually opening files or notes.