### PR TITLE
Add citar-export-buffer-citations-to-file

### DIFF
--- a/citar-markdown.el
+++ b/citar-markdown.el
@@ -124,5 +124,19 @@ citation."
              (cons (nreverse keys) (cons startpos endpos))))))
      (reverse (nth 9 (syntax-ppss))))))
 
+;;;###autoload
+(defun citar-markdown-list-keys ()
+  "Returns a list of all keys from markdown citations in buffer."
+  (interactive)
+  (save-match-data
+    (let ((pos 0)
+          matches)
+      (while (string-match citar-markdown-citation-key-regexp (buffer-string) pos)
+        (setq pos (match-end 0))
+        (push (car (split-string (match-string-no-properties 0 (buffer-string))
+                                 nil t ".*@\\|\\,.*\\]"))
+              matches))
+      (delete-dups (nreverse matches)))))
+
 (provide 'citar-markdown)
 ;;; citar-markdown.el ends here

--- a/citar-org.el
+++ b/citar-org.el
@@ -331,6 +331,14 @@ With optional argument FORCE, force the creation of a new ID."
                  (<= (point) (cdr bounds)))
         element))))
 
+(defun citar-org-list-keys ()
+  "List citation keys in the org buffer."
+  (let ((org-tree (org-element-parse-buffer)))
+    (delete-dups
+     (org-element-map org-tree 'citation-reference
+       (lambda (r) (org-element-property :key r))
+       org-tree))))
+
 ;; most of this section is adapted from org-ref-cite
 
 (defun citar-org-activate-keymap (citation)


### PR DESCRIPTION
Adds `citar-export-buffer-citations-to-file` as suggested in issue #459, @pemocarlo.

Also adds `citar-markdown-list-keys`.

EDIT: (see comment below)
~~Currently only available `latex-mode` and `markdown-mode`.~~

~~Support for `org-mode` would require a function that lists all org-citations in buffer, which is more than I can undertake at this point.~~

Thoughts on function name? Other issues?