### PR TITLE
fix: citar--insert-bibtex and citar-export-local-bib-file

### DIFF
--- a/citar-latex.el
+++ b/citar-latex.el
@@ -30,6 +30,7 @@
 (require 'citar)
 (require 'tex nil t)
 (require 'reftex-parse)
+(require 'reftex-cite)
 
 (defvar citar-major-mode-functions)
 

--- a/citar.el
+++ b/citar.el
@@ -865,6 +865,7 @@ With prefix, rebuild the cache before offering candidates."
           (seq-concatenate 'list citar-bibliography (citar--local-files-to-cache)))
          (entry
           (with-temp-buffer
+            (bibtex-set-dialect)
             (dolist (bib-file bibtex-files)
               (insert-file-contents bib-file))
             (bibtex-find-entry key)


### PR DESCRIPTION
Sets bibtex-dialect before running functions from bibtex.el