### PR TITLE
Add :filter argument to `citar-select-ref`

### DIFF
--- a/citar-file.el
+++ b/citar-file.el
@@ -206,16 +206,21 @@ need to scan the contents of DIRS in this case."
                  (puthash key (nreverse filelist) files))
                files))))
 
-(defun citar-file--has-file-p (dirs extensions &optional additional-sep entry-field)
+(defun citar-file--make-file-predicate (dirs extensions &optional entry-field)
   "Return predicate testing whether a key and entry have associated files.
 
 Files are found in two ways:
 
-- In DIRS using `citar-file--directory-files`; see its
-documentation for the meaning of EXTENSIONS and ADDITIONAL-SEP.
+- By scanning DIRS for files with EXTENSIONS using
+  `citar-file--directory-files`, which see.  Its ADDITIONAL-SEP
+  argument is taken from `citar-file-additional-files-separator`.
 
-- In the entry field ENTRY-FIELD, when it is non-nil."
-  (let ((files (citar-file--directory-files dirs nil extensions additional-sep)))
+- When ENTRY-FIELD is non-nil, by parsing the entry field it
+  names using `citar-file--parse-file-field`; see its
+  documentation.  DIRS is used to resolve relative paths and
+  non-existent files are ignored."
+  (let ((files (citar-file--directory-files dirs nil extensions
+                                            citar-file-additional-files-separator)))
     (lambda (key entry)
       (or (car (gethash key files))
           (when entry-field
@@ -235,16 +240,16 @@ EXTENSIONS, and how files are found."
 KEYS-ENTRIES is a list of (KEY . ENTRY) pairs.  Return a list of
 files found in two ways:
 
-- Scan directories in DIRS for files starting with keys in
+- By scanning directories in DIRS for files starting with keys in
   KEYS-ENTRIES and having extensions in EXTENSIONS.  The files
   may also have additional text after the key, separated by the
   value of `citar-file-additional-files-separator`.  The scanning
   is performed by `citar-file--directory-files`, which see.
 
-- Parse the entries in KEYS-ENTRIES and find file names listed in
-  the field named by `citar-file-variable`.  Relative paths are
-  resolved in the directories in DIRS, and only existing files
-  are returned."
+- By parsing the field named by `citar-file-variable` of the
+  entries in KEYS-ENTRIES.  DIRS is used to resolve relative
+  paths and non-existent files are ignored; see
+  `citar-file--parse-file-field`."
   (let* ((keys (seq-map #'car keys-entries))
          (files (citar-file--directory-files dirs keys extensions
                                              citar-file-additional-files-separator)))

--- a/citar-file.el
+++ b/citar-file.el
@@ -218,7 +218,11 @@ Files are found in two ways:
 - When ENTRY-FIELD is non-nil, by parsing the entry field it
   names using `citar-file--parse-file-field`; see its
   documentation.  DIRS is used to resolve relative paths and
-  non-existent files are ignored."
+  non-existent files are ignored.
+
+Note: for performance reasons, this function should be called
+once per command; the function it returns can be called
+repeatedly."
   (let ((files (citar-file--directory-files dirs nil extensions
                                             citar-file-additional-files-separator)))
     (lambda (key entry)

--- a/citar-file.el
+++ b/citar-file.el
@@ -206,7 +206,7 @@ need to scan the contents of DIRS in this case."
                  (puthash key (nreverse filelist) files))
                files))))
 
-(defun citar-file--make-file-predicate (dirs extensions &optional entry-field)
+(defun citar-file--has-file (dirs extensions &optional entry-field)
   "Return predicate testing whether a key and entry have associated files.
 
 Files are found in two ways:

--- a/citar.el
+++ b/citar.el
@@ -350,17 +350,27 @@ where ENTRY is a field-value alist.  Therefore 'car' of the
 return value is the cite key, and 'cdr' is an alist of structured
 data.
 
-Includes the following optional arguments:
+Takes the following optional keyword arguments:
 
-REBUILD-CACHE if t, forces rebuilding the cache before offering
-the selection candidates.
+REBUILD-CACHE: if t, forces rebuilding the cache before offering
+  the selection candidates.
 
-MULTIPLE if t, calls `completing-read-multiple` and returns an
-alist of (KEY . ENTRY) pairs.
+MULTIPLE: if t, calls `completing-read-multiple` and returns an
+  alist of (KEY . ENTRY) pairs.
 
-FILTER, if non-nil, should be a predicate function taking
-arguments KEY and ENTRY.  Only candidates for which this function
-returns non-nil will be offered for completion."
+FILTER: if non-nil, should be a predicate function taking
+  arguments KEY and ENTRY.  Only candidates for which this
+  function returns non-nil will be offered for completion.  For
+  example:
+
+  (citar-select-ref :filter (citar-has-file))
+
+  (citar-select-ref :filter (citar-has-note))
+
+  (citar-select-ref
+   :filter (lambda (_key entry)
+             (when-let ((keywords (assoc-default \"keywords\" entry)))
+               (string-match-p \"foo\" keywords))))"
   (let* ((candidates (citar--get-candidates rebuild-cache))
          (completions (citar--completion-table candidates filter))
          (embark-transformer-alist (citar--embark-transformer-alist candidates))

--- a/citar.el
+++ b/citar.el
@@ -514,6 +514,33 @@ personal names of the form 'family, given'."
    (list citar-file-variable)
    citar-additional-fields))
 
+(defun citar-has-file ()
+  "Return predicate testing whether entry has associated files.
+
+Return a function that takes arguments KEY and ENTRY and returns
+non-nil when the entry has associated files, either in
+`citar-library-paths` or the field named in
+`citar-file-variable`.
+
+Note: for performance reasons, this function should be called
+once per command; the function it returns can be called
+repeatedly."
+  (citar-file--make-file-predicate citar-library-paths
+                                   citar-file-extensions
+                                   citar-file-variable))
+
+(defun citar-has-note ()
+  "Return predicate testing whether entry has associated notes.
+
+Return a function that takes arguments KEY and ENTRY and returns
+non-nil when the entry has associated notes in `citar-notes-paths`.
+
+Note: for performance reasons, this function should be called
+once per command; the function it returns can be called
+repeatedly."
+  (citar-file--make-file-predicate citar-notes-paths
+                                   citar-file-note-extensions))
+
 (defun citar--format-candidates (bib-files &optional context)
   "Format candidates from BIB-FILES, with optional hidden CONTEXT metadata.
 This both propertizes the candidates for display, and grabs the
@@ -521,11 +548,8 @@ key associated with each one."
   (let* ((candidates nil)
          (raw-candidates
           (parsebib-parse bib-files :fields (citar--fields-to-parse)))
-         (hasfilep (citar-file--make-file-predicate citar-library-paths
-                                                    citar-file-extensions
-                                                    citar-file-variable))
-         (hasnotep (citar-file--make-file-predicate citar-notes-paths
-                                                    citar-file-note-extensions))
+         (hasfilep (citar-has-file))
+         (hasnotep (citar-has-note))
          (main-width (citar--format-width (citar-get-template 'main)))
          (suffix-width (citar--format-width (citar-get-template 'suffix)))
          (symbols-width (string-width (citar--symbols-string t t t)))


### PR DESCRIPTION
For example, this can be used to select a reference that has a note:
``` emacs-lisp
(citar-select-ref :filter (citar-make-note-predicate))
```
or to select a reference that has an associated file:
``` emacs-lisp
(citar-select-ref :filter (citar-make-file-predicate))
```
or to select a reference that has a "keywords" field containing "ethics":
```emacs-lisp
(citar-select-ref :filter (lambda (_key entry)
                            (when-let ((keywords (assoc-default "keywords" entry)))
                              (string-match-p "ethics" keywords))))
```
Also simplify and update documentation for functions in `citar-file.el`

Closes #272.