### PR TITLE
citar-markdown-list-keys: Use `citar-markdown-citation-key-regexp`

### DIFF
--- a/citar-markdown.el
+++ b/citar-markdown.el
@@ -130,10 +130,8 @@ citation."
   (save-excursion
     (let (matches)
       (goto-char (point-min))
-      (while (re-search-forward "@" nil t)
-        (push (buffer-substring-no-properties
-               (point) (1- (re-search-forward "[]\s,.;]")))
-              matches))
+      (while (re-search-forward citar-markdown-citation-key-regexp nil t)
+        (push (match-string-no-properties 1) matches))
       (delete-dups (nreverse matches)))))
 
 (provide 'citar-markdown)

--- a/citar-markdown.el
+++ b/citar-markdown.el
@@ -38,6 +38,18 @@
   :group 'citar-markdown
   :type 'boolean)
 
+(defconst citar-markdown-citation-key-regexp
+  (concat "-?@"                         ; @ preceded by optional -
+          "\\(?:"
+          "{\\(?1:.*?\\)}"              ; brace-delimited key
+          "\\|"
+          "\\(?1:[[:alnum:]_][[:alnum:]]*\\(?:[:.#$%&+?<>~/-][[:alnum:]]+\\)*\\)"
+          "\\)")
+  "Regular expression for a Pandoc citation key.
+Captures the actual key in group 1.  Implements the syntax
+specified at URL
+'https://pandoc.org/MANUAL.html#citation-syntax'.")
+
 ;;;###autoload
 (defun citar-markdown-insert-keys (keys)
   "Insert semicolon-separated and @-prefixed KEYS in a markdown buffer."
@@ -77,15 +89,6 @@ to the beginning of the citation."
 With ARG non-nil, rebuild the cache before offering candidates."
   (citar-markdown-insert-citation
    (citar--extract-keys (citar-select-refs :rebuild-cache arg))))
-
-(defconst citar-markdown-citation-key-regexp
-  (concat "-?@"                         ; @ preceded by optional -
-          "\\(?:"
-          "{\\(?1:.*?\\)}"              ; brace-delimited key
-          "\\|"
-          "\\(?1:[[:alnum:]_][[:alnum:]]*\\(?:[:.#$%&+?<>~/-][[:alnum:]]+\\)*\\)"
-          "\\)")
-  "Regular expression for a citation key.")
 
 ;;;###autoload
 (defun citar-markdown-key-at-point ()


### PR DESCRIPTION
Correctly handle Pandoc citation keys with braces:
- In `@{Foo_Bar}:`, the citation key is `Foo_Bar`, not `{Foo_Bar}:`
- Also respect Pandoc's punctuation rule: in `@Foo_bar.baz.`, the citation key is `Foo_bar.baz`.

See https://pandoc.org/MANUAL.html#citation-syntax for more examples.