### PR TITLE
Add groups to citar-open functions

### DIFF
--- a/citar-file.el
+++ b/citar-file.el
@@ -296,7 +296,7 @@ of files found in two ways:
 
 (defun citar-file-open (file)
   "Open FILE."
-  (funcall citar-file-open-function file))
+  (funcall citar-file-open-function (expand-file-name file)))
 
 (defun citar-file-open-external (file)
   "Open FILE with external application."

--- a/citar-file.el
+++ b/citar-file.el
@@ -311,20 +311,18 @@ of files found in two ways:
                   nil 0 nil
                   file)))
 
-(defun citar-file--get-note-filename (key dirs extensions)
-  "Return existing or new filename for KEY in DIRS with extension in EXTENSIONS.
+(defun citar-file--get-note-filenames (key dirs extensions)
+  "Return list of existing notes or a new filename for KEY in DIRS with extension in EXTENSIONS.
 
-This is for use in a note function where notes are one-per-file,
-with citekey as filename.
-
-Returns the filename whether or not the file exists, to support a
-function that will open a new file if the note is not present."
-  (let ((files (citar-file--directory-files dirs (list key) extensions
-                                            citar-file-additional-files-separator)))
-    (or (car (gethash key files))
-        (when-let ((dir (car dirs))
-                   (ext (car extensions)))
-          (expand-file-name (concat key "." ext) dir)))))
+If no notes exist, returns a filename to support a function that
+will open a new file if the note is not present."
+  (if-let* ((files
+             (gethash key (citar-file--directory-files dirs
+                                                       (list key)
+                                                       extensions
+                                                       citar-file-additional-files-separator))))
+      files
+    (list (concat (car dirs) "/" key "." (car extensions)))))
 
 (provide 'citar-file)
 ;;; citar-file.el ends here

--- a/citar.el
+++ b/citar.el
@@ -55,6 +55,7 @@
 (defvar embark-meta-map)
 (defvar embark-transformer-alist)
 (defvar embark-multitarget-actions)
+(defvar embark-default-action-overrides)
 (defvar citar-org-open-note-function)
 
 ;;; Variables

--- a/citar.el
+++ b/citar.el
@@ -993,7 +993,8 @@ With prefix, rebuild the cache before offering candidates."
                     (car files))))
       (if (file-exists-p file)
           (find-file (expand-file-name file))
-        (funcall citar-format-note-function key entry (expand-file-name file)))
+        (when (yes-or-no-p (format "No note associated with %s. Create one?" key))
+          (funcall citar-format-note-function key entry (expand-file-name file))))
     (find-file (citar-select-resource files))))
 
 ;;;###autoload
@@ -1062,7 +1063,7 @@ With prefix, rebuild the cache before offering candidates."
     (dolist (key-entry (citar--ensure-entries keys-entries))
       (let ((link (citar-get-link (cdr key-entry))))
 	(if link
-            (browse-url-default-browser link)
+            (browse-url link)
           (message "No link found for %s" (car key-entry)))))))
 
 ;;;###autoload

--- a/citar.el
+++ b/citar.el
@@ -419,8 +419,8 @@ documentation for the return value and the meaning of
 REBUILD-CACHE and FILTER."
   (citar-select-ref :rebuild-cache rebuild-cache :multiple t :filter filter))
 
-(defun citar-select-resources (files &optional links)
-  "Select resource(s) from a list of FILES, and optionally LINKS."
+(defun citar-select-resource (files &optional links)
+  "Select resource from a list of FILES, and optionally LINKS."
   (let* ((files (mapcar
                  (lambda (cand)
                    (abbreviate-file-name cand))
@@ -914,7 +914,7 @@ into the corresponding reference key.  Return
            (lambda (key-entry)
              (citar-get-link (cdr key-entry)))
            key-entry-alist))
-         (selection (citar-select-resources files links)))
+         (selection (citar-select-resource files links)))
     (if files
         (cond ((string-match "http" selection 0)
                (browse-url selection))
@@ -933,9 +933,9 @@ into the corresponding reference key.  Return
              citar-file-extensions)))
       (if (and citar-file-open-prompt
                (> (length files) 1))
-          (let ((selection (citar-select-resources files)))
+          (let ((selection (citar-select-resource files)))
             (funcall fn selection))
-        (funcall fn files))
+        (funcall fn (car files)))
     (message "No associated file")))
 
 ;;;###autoload
@@ -981,7 +981,7 @@ With prefix, rebuild the cache before offering candidates."
       (if (file-exists-p file)
           (find-file (expand-file-name file))
         (funcall citar-format-note-function key entry (expand-file-name file)))
-    (find-file (citar-select-resources files))))
+    (find-file (citar-select-resource files))))
 
 ;;;###autoload
 (defun citar-open-entry (keys-entries)
@@ -1043,7 +1043,6 @@ directory as current buffer."
   "Open URL or DOI link associated with the KEYS-ENTRIES in a browser.
 
 With prefix, rebuild the cache before offering candidates."
-  ;;      (browse-url-default-browser "https://google.com")
   (interactive (list (citar-select-refs
                       :rebuild-cache current-prefix-arg)))
   (dolist (key-entry (citar--ensure-entries keys-entries))

--- a/citar.el
+++ b/citar.el
@@ -964,12 +964,20 @@ With prefix, rebuild the cache before offering candidates."
 
 (defun citar--open-note (key entry)
   "Open a note file from KEY and ENTRY."
-  (if-let* ((file (citar-file--get-note-filename key
-                                                 citar-notes-paths
-                                                 citar-file-note-extensions))
-            (file-exists (file-exists-p file)))
-      (find-file file)
-    (funcall citar-format-note-function key entry file)))
+  (if-let* ((raw-files (citar-file--get-note-filenames key
+                                                       citar-notes-paths
+                                                       citar-file-note-extensions))
+            (files
+             (mapcar
+              (lambda (file)
+                (abbreviate-file-name file))
+              raw-files))
+            (file (when (= (length files) 1)
+                    (car files))))
+      (if  (file-exists-p file)
+          (find-file (expand-file-name file))
+        (funcall citar-format-note-function key entry (expand-file-name file)))
+    (find-file (expand-file-name (completing-read "Open note: " files nil t)))))
 
 ;;;###autoload
 (defun citar-open-entry (keys-entries)


### PR DESCRIPTION
Changes:
- Adds `completing-read` to `citar--open-note`, for when multiple notes exist

- Changes `citar-select-files` to `citar-select-resources`, and calls the new function in both `citar-open` and `citar-open-library-files`

- Adds group-function, `citar-select-group-related-resources`, to `citar-select-resources`, to group candidates by type

The result of calling `citar-open` on an entry with associated files, notes, and a link (the following shows `vertico` with the `consult-completing-read-multiple` interface):
![citar-open file-link-note](https://user-images.githubusercontent.com/78040295/146552364-853bd6c3-6e5b-4bdd-aace-72dd418c2a96.jpg)

Selecting multiple file types, a note and a file:
![citar-open file-link-note selected](https://user-images.githubusercontent.com/78040295/146552354-8e7c0ce0-ff02-4597-918c-bd92c39cec78.jpg)


Todo:
~- Somehow set proper category metadata for links in `citar-select-resources`. I'm actually not sure if this is possible.
    - Note that prior to this PR, `citar-open` did not add any metadata to candidates, so `embark-act`'ing on a file candidate did not make embark file functions available. Now embark file functions are available, but on both files _and_ links. Neither case seems optimal, if it's not possible (or easy) to set category metadata by group.~


Question:
~- Does this work as expected with `embark-act-all`? I've not used that enough to properly test it.~
