### PR TITLE
Add invert-prompt argument to citar-markdown-insert-citation

### DIFF
--- a/citar-markdown.el
+++ b/citar-markdown.el
@@ -56,7 +56,7 @@ specified at URL
   (insert (mapconcat (lambda (k) (concat "@" k)) keys "; ")))
 
 ;;;###autoload
-(defun citar-markdown-insert-citation (keys)
+(defun citar-markdown-insert-citation (keys &optional invert-prompt)
   "Insert a pandoc-style citation consisting of KEYS.
   
 If the point is inside a citation, add new keys after the current
@@ -66,16 +66,15 @@ If point is immediately after the opening \[, add new keys
 to the beginning of the citation."
   (let* ((citation (citar-markdown-citation-at-point))
          (keys (if citation (seq-difference keys (car citation)) keys))
-         (keyconcat (mapconcat (lambda (k) (concat "@" k)) keys "; ")))
+         (keyconcat (mapconcat (lambda (k) (concat "@" k)) keys "; "))
+         (prompt (xor invert-prompt citar-markdown-prompt-for-extra-arguments)))
     (when keys
       (if (or (not citation)
               (= (point) (cadr citation))
               (= (point) (cddr citation)))
-          (let* ((prenote  (when citar-markdown-prompt-for-extra-arguments
-                             (read-from-minibuffer "Prenote: ")))
-                 (postnote (when citar-markdown-prompt-for-extra-arguments
-                             (read-from-minibuffer "Postnote: ")))
-                 (prenote  (if (string= "" prenote)  "" (concat prenote " ")))
+          (let* ((prenote (when prompt (read-from-minibuffer "Prenote: ")))
+                 (postnote (when prompt (read-from-minibuffer "Postnote: ")))
+                 (prenote (if (string= "" prenote)  "" (concat prenote " ")))
                  (postnote (if (string= "" postnote) "" (concat ", " postnote))))
             (insert (format "[%s%s%s]" prenote keyconcat postnote)))
         (if (= (point) (1+ (cadr citation)))


### PR DESCRIPTION
When calling `citar-insert-citation` with a prefix argument, the meaning of `citar-markdown-prompt-for-extra-arguments` is now inverted.

Fixes #499.