### PR TITLE
Add error handling to citar-insert-citation and citar-open

### DIFF
--- a/citar.el
+++ b/citar.el
@@ -932,8 +932,9 @@ into the corresponding reference key.  Return
            key-entry-alist))
          (resource-candidates (delete-dups (append files (remq nil links))))
          (resource
-          (when resource-candidates
-            (citar-select-resource files links))))
+          (if resource-candidates
+              (citar-select-resource files links)
+            (error "No associated resources"))))
     (citar-open-multi resource)))
 
 (defun citar-open-multi (selection)
@@ -1074,14 +1075,16 @@ With prefix, rebuild the cache before offering candidates."
 Prefix ARG is passed to the mode-specific insertion function. It
 should invert the default behaviour for that mode with respect to
 citation styles. See specific functions for more detail."
-  (interactive (list (citar-select-refs) ; key-entries
-		     current-prefix-arg)) ; arg
+  (interactive
+   (if (member major-mode citar-major-modes)
+       (list (citar-select-refs)  ; key-entries
+	     current-prefix-arg) ; arg
+     (error "Citation insertion is not supported for %s" major-mode)))
   (citar--major-mode-function
    'insert-citation
-   (lambda (&rest _)
-     (message "Citation insertion is not supported for %s" major-mode))
+   #'ignore
    (citar--extract-keys keys-entries)
-    arg))
+   arg))
 
 (defun citar-insert-edit (&optional arg)
   "Edit the citation at point."

--- a/citar.el
+++ b/citar.el
@@ -277,6 +277,9 @@ of all citations in the current buffer."
   :group 'citar
   :type 'alist)
 
+(defvar citar-major-modes '(org-mode latex-mode markdown-mode)
+  "List of supported major modes.")
+
 ;;; History, including future history list.
 
 (defvar citar-history nil

--- a/citar.el
+++ b/citar.el
@@ -277,9 +277,6 @@ of all citations in the current buffer."
   :group 'citar
   :type 'alist)
 
-(defvar citar-major-modes '(org-mode latex-mode markdown-mode)
-  "List of supported major modes.")
-
 ;;; History, including future history list.
 
 (defvar citar-history nil
@@ -1079,7 +1076,9 @@ Prefix ARG is passed to the mode-specific insertion function. It
 should invert the default behaviour for that mode with respect to
 citation styles. See specific functions for more detail."
   (interactive
-   (if (member major-mode citar-major-modes)
+   (if (member major-mode (mapcar
+                           'caar
+                           (butlast citar-major-mode-functions)))
        (list (citar-select-refs)  ; key-entries
 	     current-prefix-arg) ; arg
      (error "Citation insertion is not supported for %s" major-mode)))


### PR DESCRIPTION
Adds a major-mode check to `citar-insert-citation`
Fixes #441

~Adds a defvar `citar-major-modes`; a list of currently supported major modes. (This list could be made programatically, but that seemed like overkill.)~

Adds "No associated resource" message to `citar-open`, sidestepping a "Wrong type argument" error.