### PR TITLE
Update README to also set citar-bibliography

### DIFF
--- a/README.org
+++ b/README.org
@@ -100,6 +100,7 @@ If you want to use Citar only in Org-Mode, this is the best option.
   (org-cite-insert-processor 'citar)
   (org-cite-follow-processor 'citar)
   (org-cite-activate-processor 'citar)
+  (citar-bibliography org-cite-global-bibliography)
   ;; optional: org-cite-insert is also bound to C-c C-x C-@
   :bind
   (:map org-mode-map :package org ("C-c b" . #'org-cite-insert)))


### PR DESCRIPTION
The current org-cite example doesn't seem to work for me unless I set `citar-bibliography` (I get "Make sure to set citar-bibliography" if I try to insert a citation). This change just updates the readme to set this variable.