### PR TITLE
Update default value of `citar-templates`

### DIFF
--- a/citar.el
+++ b/citar.el
@@ -101,7 +101,7 @@ to include."
 (defcustom citar-templates
   '((main . "${author editor:30}     ${date year issued:4}     ${title:48}")
     (suffix . "          ${=key= id:15}    ${=type=:12}    ${tags keywords keywords:*}")
-    (preview . "${author editor} (${year issued date}) ${title}, ${journal publisher container-title collection-title}.\n")
+    (preview . "${author editor} (${year issued date}) ${title}, ${journal journaltitle publisher container-title collection-title}.\n")
     (note . "Notes on ${author editor}, ${title}"))
   "Configures formatting for the bibliographic entry.
 


### PR DESCRIPTION
Biblatex prefers 'journaltitle' to 'journal', and at least prior to Emacs 28, `bibtex.el` wouldn't even recognize 'journal' as an alias for 'journaltitle' if you had `bibtex-dialect` set to `biblatex`. This small change is just to reflect the fact that many entries biblatex is happy with lack a 'journal' field but have a 'journaltitle' field.