### PR TITLE
Add initial-input argument to citar-select-ref

### DIFF
--- a/citar.el
+++ b/citar.el
@@ -352,7 +352,7 @@ and other completion functions."
                           (or (null predicate) (funcall predicate cand))))))))
           (complete-with-action action candidates string predicate))))))
 
-(cl-defun citar-select-ref (&optional &key rebuild-cache multiple filter)
+(cl-defun citar-select-ref (&optional &key rebuild-cache multiple filter initial-input)
   "Select bibliographic references.
 
 A wrapper around 'completing-read' that returns (KEY . ENTRY),
@@ -380,15 +380,17 @@ FILTER: if non-nil, should be a predicate function taking
   (citar-select-ref
    :filter (lambda (_key entry)
              (when-let ((keywords (assoc-default \"keywords\" entry)))
-               (string-match-p \"foo\" keywords))))"
+               (string-match-p \"foo\" keywords))))
+
+INITIAL-INPUT: Initial input passed to completing-read."
   (let* ((candidates (citar--get-candidates rebuild-cache))
          (completions (citar--completion-table candidates filter))
          (embark-transformer-alist (citar--embark-transformer-alist candidates))
          (crm-separator "\\s-*&\\s-*")
          (chosen (if (and multiple citar-select-multiple)
-                     (completing-read-multiple "References: " completions nil nil nil
+                     (completing-read-multiple "References: " completions nil nil initial-input
                                                'citar-history citar-presets nil)
-                   (completing-read "Reference: " completions nil nil nil
+                   (completing-read "Reference: " completions nil nil initial-input
                                     'citar-history citar-presets nil)))
          (notfound nil)
          (keyentries


### PR DESCRIPTION
This can be useful when invoking it from another function, like
`org-roam-capture`.

My use case is for creating a new reading note with org-roam. If `org-roam-node-find` doesn’t find the author/title searched for, this is passed to `org-roam-capture`, where the citar search is initiated from the entered search string in roam ("${title}" in the capture template below).

I bypass the citar machinery in for file-notes here, because it seemed to assume a one note per file-system (the old org-roam way) which I don’t like (I currently use yearly files with date-trees for my notes).

``` emacs-lisp
(setq org-roam-capture-templates
'(
("l"
"Reading notes"
entry
"* Read %(aj/org-return-reference-author-year-title \"${title}\") :#reading%^g
:PROPERTIES:
:ID: %(org-id-new)
:ROAM_REFS: %(aj/org-last-returned-citation-key)
:END:
%U
%i
%?"
:empty-lines-before 1
:target (file+datetree "~/notes/notes-%<%Y>.org" month))))


(defvar aj/org-last-returned-citation-key nil)
(defun aj/org-last-returned-citation-key ()
  aj/org-last-returned-citation-key)

(defun aj/org-return-reference-author-year-title (&optional initial-input)
  "Fetch a simply formatted reference and return it as a string.
Possibly passss INITIAL-INPUT"
  (let* ((ref (citar-select-ref :initial-input initial-input))
         (key (car ref)))
    (setq aj/org-last-returned-citation-key key)
    (citar--format-entry-no-widths ref "${author editor} (${year issued date}) /${title}/")))
```