### PR TITLE
Use format-spec instead of s-format

### DIFF
--- a/README.org
+++ b/README.org
@@ -160,21 +160,44 @@ For the prefix, you can filter for associated files or notes using =has:file= or
 *** Templates
 
 The =citar-templates= variable configures formatting for these sections, as well as the default note function.
-Here's the defaults:
+Here are the defaults:
 
 #+BEGIN_SRC emacs-lisp
 (setq citar-templates
-      '((main . "${author editor:30}     ${date year issued:4}     ${title:48}")
-        (suffix . "          ${=key= id:15}    ${=type=:12}    ${tags keywords:*}")
-        (note . "Notes on ${author editor}, ${title}")))
+      '((main . "%->30a     %>4d     %->48t")
+        (suffix . "          %>15k    %>12T   %K")
+        (preview . "%>a (%>4d) %t, %p.\n")
+        (note . "Notes on %a, %t")))
 #+END_SRC
+
+The formatting is done using Emacs's built-in =format-spec= library. For
+details about setting the templates, see that library and the GNU Emacs Lisp
+Reference Manual =(info "(elisp) Custom Format Strings")=.
+
+For purposes specific to Citar, each alphabetic character in the templates
+above (e.g., "a", "d", "t", etc.) is keyed to one or more bibliographic
+fields as specified in the variable =citar-template-fields=:
+
+#+BEGIN_SRC emacs-lisp
+(setq citar-template-fields
+      '((?a . ("author" "editor"))
+        (?d . ("date" "year" "issued"))
+        (?t . ("title"))
+        (?k . ("=key="))
+        (?T . ("=type="))
+        (?K . ("tags" "keywords"))
+        (?p . ("journal" "journaltitle"
+               "publisher" "containter-title"
+               "collection-title")))
+#+END_SRC
+
+You may associated multiple field names with a given letter, as in the case
+of "a" above; the formatter will print the first one it finds.
 
 Note:
 
-1. You may include multiple variables in a field; the formatter will print the first one it finds.
-2. If you plan to use CSL JSON at all, you can and should include CSL JSON variables names where appropriate as such options. The default main template dates field demonstrates this.
-3. The asterisk signals to the formatter to use available space for the column.
-4. The note template does not take widths, as formatting is inline there rather than columnar.
+1. If you plan to use CSL JSON at all, you can and should include CSL JSON variables names where appropriate as such options. The default main template dates field demonstrates this.
+2. The note template does not take widths, as formatting is inline there rather than columnar.
 
 *** Icons
 

--- a/README.org
+++ b/README.org
@@ -1,4 +1,9 @@
+
 [[https://melpa.org/#/citar][file:https://melpa.org/packages/citar-badge.svg]]
+
+* Breaking Changes
+
+- Templating is now handled with Emacs's built-in =format-spec= library, so any customizations to the variable =citar-templates= will need to be updated to conform to that specification. See [[#templates][Templates]] for more details.
 
 * Citar
   :PROPERTIES:
@@ -194,10 +199,7 @@ fields as specified in the variable =citar-template-fields=:
 You may associated multiple field names with a given letter, as in the case
 of "a" above; the formatter will print the first one it finds.
 
-Note:
-
-1. If you plan to use CSL JSON at all, you can and should include CSL JSON variables names where appropriate as such options. The default main template dates field demonstrates this.
-2. The note template does not take widths, as formatting is inline there rather than columnar.
+Note: If you plan to use CSL JSON at all, you can and should include CSL JSON variables names where appropriate as such options. The default main template dates field demonstrates this.
 
 *** Icons
 

--- a/README.org
+++ b/README.org
@@ -174,8 +174,8 @@ The formatting is done using Emacs's built-in =format-spec= library. For
 details about setting the templates, see that library and the GNU Emacs Lisp
 Reference Manual =(info "(elisp) Custom Format Strings")=.
 
-For purposes specific to Citar, each alphabetic character in the templates
-above (e.g., "a", "d", "t", etc.) is keyed to one or more bibliographic
+For purposes specific to Citar, the alphabetic characters in the templates
+above (e.g., "a", "d", "t", etc.) are keyed to one or more bibliographic
 fields as specified in the variable =citar-template-fields=:
 
 #+BEGIN_SRC emacs-lisp

--- a/citar-file.el
+++ b/citar-file.el
@@ -31,7 +31,6 @@
 (declare-function citar-get-entry "citar")
 (declare-function citar-get-value "citar")
 (declare-function citar-get-template "citar")
-(declare-function citar--format-entry-no-widths "citar")
 
 ;;;; File related variables
 

--- a/citar-org.el
+++ b/citar-org.el
@@ -281,7 +281,7 @@ With optional argument FORCE, force the creation of a new ID."
     (let* ((template (citar-get-template 'note))
            (note-meta
             (when template
-              (citar--format-entry-no-widths
+              (citar--format-entry
                entry
                template)))
            (buffer (find-file filepath)))

--- a/citar.el
+++ b/citar.el
@@ -98,7 +98,7 @@ to include."
   :type '(repeat string))
 
 (defcustom citar-templates
-  '((main . "%->30a     %4d     %->48t")
+  '((main . "%->30a     %>4d     %->48t")
     (suffix . "          %>15k    %>12T   %K")
     (preview . "%>a (%d) %t, %p.\n")
     (note . "Notes on %a, %t"))

--- a/citar.el
+++ b/citar.el
@@ -100,7 +100,7 @@ to include."
 (defcustom citar-templates
   '((main . "%->30a     %>4d     %->48t")
     (suffix . "          %>15k    %>12T   %K")
-    (preview . "%>a (%d) %t, %p.\n")
+    (preview . "%>a (%>4d) %t, %p.\n")
     (note . "Notes on %a, %t"))
   "Configures formatting for the bibliographic entry.
 

--- a/citar.el
+++ b/citar.el
@@ -138,7 +138,7 @@ the list will be the replacement."
                 :value-type (repeat string)))
 
 (defcustom citar-format-reference-function
-#'citar-format-reference
+  #'citar-format-reference
   "Function used to render formatted references.
 
 This function is called by 'citar-insert-reference' and

--- a/citar.el
+++ b/citar.el
@@ -608,6 +608,7 @@ key associated with each one."
        (let* ((files (when (funcall hasfilep citekey entry) " has:files"))
               (notes (when (funcall hasnotep citekey entry) " has:notes"))
               (link (when (citar-has-a-value '("doi" "url") entry) "has:link"))
+              (full-fields (citar--format-entry entry "%a %t"))
               (candidate-main
                (citar--format-entry
                 entry
@@ -619,7 +620,7 @@ key associated with each one."
               ;; We display this content already using symbols; here we add back
               ;; text to allow it to be searched, and citekey to ensure uniqueness
               ;; of the candidate.
-              (candidate-hidden (string-join (list files notes link context citekey) " ")))
+              (candidate-hidden (string-join (list files notes link context citekey full-fields) " ")))
          (push
           (cons
            ;; If we don't trim the trailing whitespace,

--- a/citar.el
+++ b/citar.el
@@ -42,6 +42,7 @@
 (require 'seq)
 (require 'browse-url)
 (require 'citar-file)
+(require 'format-spec)
 (require 'parsebib)
 (require 'crm)
 


### PR DESCRIPTION
Use format-spec for display templates, rather than s-format.

This could do with some testing.

Closes #335
(Unless there are other s functions I overlooked.)