### PR TITLE
Fix citar-open-multi to open notes with find-file

### DIFF
--- a/citar.el
+++ b/citar.el
@@ -946,6 +946,10 @@ into the corresponding reference key.  Return
 For use with 'embark-act-all'."
   (cond ((string-match "http" selection 0)
          (browse-url selection))
+        ((member t (mapcar (lambda (x)
+                             (file-in-directory-p selection x))
+                           citar-notes-paths))
+         (find-file selection))
         (t (citar-file-open selection))))
 
 (defun citar--library-file-action (key-entry action)


### PR DESCRIPTION
Incorporates into the new 'citar-open-multi' a fix from #460, #465

Issue:
- when using citar-open, notes are not distinguished from files, and are therefore opened with 'citar-file-open-function'
- when 'citar-file-open-function' is set to 'citar-file-open-external', notes are opened by the system, which takes some time to find emacs
- presumably notes should be opened in emacs directly, using find-file; previously discussed in #465

Fix:
'citar-multi-open' checks directory of selection against 'citar-notes-paths'