### PR TITLE
Add option for citar-open to forego selection prompt

### DIFF
--- a/citar.el
+++ b/citar.el
@@ -425,17 +425,6 @@ documentation for the return value and the meaning of
 REBUILD-CACHE and FILTER."
   (citar-select-ref :rebuild-cache rebuild-cache :multiple t :filter filter))
 
-(defun citar-select-file (files)
-  "Select file from a list of FILES."
-  (completing-read
-   "Related file: "
-   (lambda (string predicate action)
-     (if (eq action 'metadata)
-         `(metadata
-        ; (group-function . citar-select-group-related-sources)
-           (category . file))
-       (complete-with-action action files string predicate)))))
-
 (defun citar-select-resource (files &optional links)
   "Select resource from a list of FILES, and optionally LINKS."
   (let* ((files (mapcar
@@ -978,7 +967,7 @@ For use with 'embark-act-all'."
           (pcase (length files)
             (1 (car files))
             ((guard (> 1))
-             (citar-select-file files)))))
+             (citar-select-resource files)))))
     (if file
         (funcall fn file)
       (message "No associated file"))))

--- a/citar.el
+++ b/citar.el
@@ -186,6 +186,12 @@ and nil means no action."
   :type '(radio (const :tag "Prompt" prompt)
                 (const :tag "Ignore" nil)))
 
+(defcustom citar-open-prompt t
+  "Always prompt for selection files with 'citar-open'.
+If nil, single resources will open without prompting."
+  :group 'citar
+  :type '(boolean))
+
 (defcustom citar-open-note-function
   'citar--open-note
   "Function to open a new or existing note.
@@ -196,7 +202,6 @@ KEY: a string to represent the citekey
 ENTRY: an alist with the structured data (title, author, etc.)"
   :group 'citar
   :type 'function)
-
 
 (defcustom citar-format-note-function
   'citar-org-format-note-default
@@ -934,12 +939,15 @@ into the corresponding reference key.  Return
            (lambda (key-entry)
              (citar-get-link (cdr key-entry)))
            key-entry-alist))
-         (resource-candidates (delete-dups (append files (remq nil links))))
-         (resource
-          (if resource-candidates
-              (citar-select-resource files links)
-            (error "No associated resources"))))
-    (citar-open-multi resource)))
+         (resource-candidates (delete-dups (append files (remq nil links)))))
+    (cond
+     ((eq nil resource-candidates)
+      (error "No associated resources"))
+     ((unless citar-open-prompt
+        (eq 1 (length resource-candidates)))
+      (citar-open-multi (car resource-candidates)))
+     (t (citar-open-multi
+         (citar-select-resource files links))))))
 
 (defun citar-open-multi (selection)
   "Act appropriately on SELECTION when type is 'multi-category'.


### PR DESCRIPTION
Closes #544

When citar-open-prompt is t, the default, citar-open will prompt for resource
selection even when there is only one resource. When nil, single resources
will open immediately, without any prompt.