### PR TITLE
Add preview template to README

### DIFF
--- a/README.org
+++ b/README.org
@@ -160,12 +160,13 @@ For the prefix, you can filter for associated files or notes using =has:file= or
 *** Templates
 
 The =citar-templates= variable configures formatting for these sections, as well as the default note function.
-Here's the defaults:
+Here's the default value:
 
 #+BEGIN_SRC emacs-lisp
 (setq citar-templates
       '((main . "${author editor:30}     ${date year issued:4}     ${title:48}")
         (suffix . "          ${=key= id:15}    ${=type=:12}    ${tags keywords:*}")
+        (preview . "${author editor} (${year issued date}) ${title}, ${journal journaltitle publisher container-title collection-title}.\n")
         (note . "Notes on ${author editor}, ${title}")))
 #+END_SRC
 


### PR DESCRIPTION
The previously stated default value in the README would make citar choke, since it didn't include `preview`. So I'm just updating this to reflect the actual default value.