### PR TITLE
Fix minimal configuration example

### DIFF
--- a/README.org
+++ b/README.org
@@ -69,7 +69,7 @@ This is the minimal configuration, and will work with any completing-read compli
          :map minibuffer-local-map
          ("M-b" . citar-insert-preset))
   :custom
-  (citar-bibliography '("~/bib/references.bib"))
+  (citar-bibliography '("~/bib/references.bib")))
 #+END_SRC
 
 *** Embark


### PR DESCRIPTION
The minimal configuration code example in the `README.org` missing a closing bracket `)`.
This causes an `End of file during parsing` error if the code example is copy-pasted into the Emacs config.