### PR TITLE
Change default value of `citar-additional-fields`

### DIFF
--- a/citar.el
+++ b/citar.el
@@ -89,7 +89,7 @@
   :group 'citar
   :type '(repeat directory))
 
-(defcustom citar-additional-fields '("doi" "url")
+(defcustom citar-additional-fields '("doi" "url" "crossref")
   "A list of fields to add to parsed data.
 
 By default, citar filters parsed data based on the fields


### PR DESCRIPTION
Include "crossref" in the default value of `citar-additional-fields`, to make use of `parsebib`'s ability to make use of crossref information.