### PR TITLE
Use browse-url instead of browse-url-default-browser

### DIFF
--- a/citar.el
+++ b/citar.el
@@ -1082,7 +1082,7 @@ With prefix, rebuild the cache before offering candidates."
                       :rebuild-cache current-prefix-arg)))
   (let ((link (citar-get-link (cdr key-entry))))
     (if link
-        (browse-url-default-browser link)
+        (browse-url link)
       (message "No link found for %s" (car key-entry)))))
 
 ;;;###autoload


### PR DESCRIPTION
Hi, thank you for your work on this great package.

Does this use of `browse-url-default-browser` come with some intention?
If not, I think `browse-url` is better because:
- it's consistent with other codes. `citar-open` and `citar-open-multi` use it.
- `browse-url-default-browser` doesn't care about `browse-url-browser-function` that users can set. This is actually a problem for me.
