### PR TITLE
Find files in : or ; delimited file entries.

### DIFF
--- a/README.org
+++ b/README.org
@@ -282,7 +282,7 @@ If you have ~citar-library-paths~ set, the relevant open commands will look in t
 They will also parse contents of a file-field.
 The ~citar-file-parser-functions~ variable governs which parsers to use, and there are two included parsers:
 
-1. The default =citar-file-parser-default= parser works for simple semi-colon-delimited lists of file paths, as in Zotero.
+1. The default =citar-file-parser-default= parser works for simple colon or semi-colon-delimited lists of file paths, as in Zotero.
 2. The =citar-file-parser-triplet= works for Mendeley and Calibre, which represent files using a format like =:/path/file.pdf:PDF=.
 
 If you have a mix of entries created with Zotero and Calibre, you can set it like so and it will parse both:

--- a/citar-file.el
+++ b/citar-file.el
@@ -108,7 +108,7 @@ separator that does not otherwise occur in citation keys."
 
 (defun citar-file-parser-default (dirs file-field)
   "Return a list of files from DIRS and FILE-FIELD."
-  (let ((files (split-string file-field ";")))
+  (let ((files (split-string file-field "[:;]")))
     (delete-dups
      (seq-mapcat
       (lambda (dir)


### PR DESCRIPTION
The newer Zotero style file entries have the format:

`file = {Li and Samulski 2020 - Engineering adeno-associated virus
vectors for gene therapy:files/1491/Li and Samulski 2020 - Engineering
adeno-associated virus vectors for gene therapy.pdf:application/pdf}`

This allows `citar-file-parser-default` to find the associated files
correctly.

Closes #578.