### PR TITLE
Add citar--select-multiple

### DIFF
--- a/citar-embark.el
+++ b/citar-embark.el
@@ -1,0 +1,41 @@
+;;; citar-embark.el --- Embark support for citar -*- lexical-binding: t; -*-
+;;
+;; This file is not part of GNU Emacs.
+;;
+;; This program is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation, either version 3 of the License, or
+;; (at your option) any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;;  Provides functions for integrating Embark and Citar.
+;;
+;;; Code:
+(require 'embark)
+(require 'citar)
+
+;;;###autoload
+(defun citar--embark-selected ()
+  "Return selected candidates from `citar--select-multiple' for embark."
+  (when-let (((eq minibuffer-history-variable 'citar-history))
+             (metadata (embark--metadata))
+             (group-function (completion-metadata-get metadata 'group-function))
+             (cands (all-completions
+                     "" minibuffer-completion-table
+                     (lambda (cand)
+                       (and (equal "Selected" (funcall group-function cand nil))
+                            (or (not minibuffer-completion-predicate)
+                                (funcall minibuffer-completion-predicate cand)))))))
+    (cons (completion-metadata-get metadata 'category) cands)))
+
+(provide 'citar-embark)
+;;; citar-embark.el ends here

--- a/citar-vertico.el
+++ b/citar-vertico.el
@@ -1,0 +1,66 @@
+;;; citar-vertico.el --- Keybinding remapping for vertico -*- lexical-binding: t; -*-
+;;
+;; Copyright (C) 2022 Bruce D'Arcus
+;;
+;;
+;; This file is not part of GNU Emacs.
+;;
+;;; Commentary:
+;;
+;;  Remaps keybindings for using 'citar--multiple-select' with vertico.
+;;
+;;; Code:
+
+(require 'vertico)
+
+(defvar vertico--input)
+(defvar vertico--history-hash)
+(defvar vertico--lock-candidate)
+(declare-function vertico--exhibit "ext:vertico")
+(declare-function vertico--candidate "ext:vertico")
+
+(defun citar-vertico--candidate ()
+  "Return current candidate for Consult preview."
+  (and vertico--input (vertico--candidate 'highlight)))
+
+(defun citar-vertico--refresh (&optional reset)
+  "Refresh completion UI, keep current candidate unless RESET is non-nil."
+  (when vertico--input
+    (setq vertico--input t)
+    (when reset
+      (setq vertico--history-hash nil
+            vertico--lock-candidate nil))
+    (vertico--exhibit)))
+
+(defun citar-vertico--crm-select ()
+  "Select/deselect candidate."
+  (interactive)
+  (when (let ((cand (vertico--candidate)))
+          (and (vertico--match-p cand) (not (equal cand ""))))
+    (vertico-exit)))
+
+(defun citar-vertico--crm-exit ()
+  "Select/deselect candidate and exit."
+  (interactive)
+  (when (let ((cand (vertico--candidate)))
+          (and (vertico--match-p cand) (not (equal cand ""))))
+    (run-at-time 0 nil #'exit-minibuffer))
+  (vertico-exit))
+
+(defvar citar-vertico--crm-map
+  (let ((map (make-sparse-keymap)))
+    (define-key map [remap vertico-insert] #'citar-vertico--crm-select)
+    (define-key map [remap exit-minibuffer] #'citar-vertico--crm-exit)
+    map))
+
+(defun citar-vertico--crm-setup ()
+  "Setup crm for Vertico."
+  (when vertico--input
+    (use-local-map (make-composed-keymap (list citar-vertico--crm-map) (current-local-map)))))
+
+(add-hook 'citar--completion-candidate-hook #'citar-vertico--candidate)
+(add-hook 'citar--completion-refresh-hook #'citar-vertico--refresh)
+(add-hook 'citar--crm-setup-hook #'citar-vertico--crm-setup)
+
+(provide 'citar-vertico)
+;;; citar-vertico.el ends here


### PR DESCRIPTION
This replaces completing-read-multiple with a simple alternative,
courtesy of minad (see #160), that calls completing-read in a loop.

See #582

---------

This works, but needs testing, and polish. Details:

1.  ~history doesn't work currently, even though I added a "history" argument.~
2.  I assume since this uses grouping, it won't work pre-Emacs 28. But that was true for consult-crm. Need to address.
3. Will this work with Embark? Currently it doesn.t
4.  ideally we could have this work like the vertico-crm prototype; `TAB` selects and deselects, and `RET` completes. Is that possible, @minad?

On 4, maybe want to borrow from [earlier consult](https://github.com/minad/consult/blob/4e553d5fff3b1774d956e8f5259cf781cf3f9929/consult-vertico.el)?

I've added my adaptation here in a commit for `citar-vertico.el`, though it doesn't work correctly currently. When I do `M-x` I have to use `TAB` to select the command, which is obviously not what we want. Rather, I only want this rebinding to happen with `citar--select-multiple`. But I don't really understand this code. Any suggestions?

cc @aikrahguzar @localauthor 