### PR TITLE
Add file/note data to candidates

### DIFF
--- a/citar.el
+++ b/citar.el
@@ -605,6 +605,8 @@ key associated with each one."
               ;; text to allow it to be searched, and citekey to ensure uniqueness
               ;; of the candidate.
               (candidate-hidden (string-join (list files notes link context citekey) " ")))
+         (when files (push (cons "has-file" t) entry))
+         (when notes (push (cons "has-note" t) entry))
          (push
           (cons
            ;; If we don't trim the trailing whitespace,


### PR DESCRIPTION
Currently, this PR has two commits, both to facilitate programmatic filtering etc of candidates.

## Add cons cells to candidate entries

First, when creating candidates, it adds cons cells for files or notes, I can drop this commit if we prefer the more general solution below, but I don't believe the operations here (pushing cons to a list) are expensive.

```elisp
(("has-note" . t) ; this PR adds this and next line
 ("has-file" . t)
 ("doi" . "10.1111/j.1540-6040.2009.01269.x")
 ("journaltitle" . "City \\& Community")
 ("date" . "2009-03-01")
 ("author" . "Zukin, Sharon and Trujillo, Valerie and Frase, Peter and Jackson, Danielle and Recuber, Tim and Walker, Abraham")
 ("title" . "New Retail Capital and Neighborhood Change: Boutiques and Gentrification in {{New York City}}")
 ("=type=" . "article")
 ("=key=" . "zukin2009"))
``` 

To filter:

```elisp
(seq-filter 
  (lambda (entry) 
    (assoc "has-note" entry)) 
  (citar--get-candidates))
```
## Add filter arg to `citar--get-candidates`

Second, more generally, it adds an optional filter to `citar--get-candidates`:

```elisp
(citar--get-candidates t (citar-has-note))
```

FWIW, this is actually slower than the first option.

```elisp
ELISP> (benchmark-run-compiled 10 (citar--get-candidates nil (citar-has-note)))
(0.036507296 0 0.0)

ELISP> (benchmark-run-compiled 10 (seq-filter 
    (lambda (e) 
      (assoc "has-note" e)) 
  (citar--get-candidates)))
(0.004006728 0 0.0)
```

See https://github.com/Vidianos-Giannitsis/zetteldesk.el/issues/5

Close #594