### PR TITLE
Generalize note API

### DIFF
--- a/README.org
+++ b/README.org
@@ -267,14 +267,20 @@ For additional configuration options on this, see [[https://github.com/bdarcus/c
 
 ** Notes
 
-Citar provides a ~citar-format-note-function~ variable, and a default function for org, which also works well with org-roam (v2 now supports org-cite).
+Citar provides a ~citar-create-note-function~ variable, and a default function for org, which also works well with org-roam (v2 now supports org-cite).
 You can configure the title display using the "note" template.
 
-You can also use the ~citar-open-note-function~ variable to replace the default with another; for example from org-roam-bibtex:
+You can also use the ~citar-open-note-functions~ variable to replace or augment the default with another; for example from org-roam-bibtex:
 
 #+BEGIN_SRC emacs-lisp
-(setq citar-open-note-function 'orb-citar-edit-note)
+(setq citar-open-note-functions '(orb-citar-edit-note))
 #+END_SRC
+
+Since ~citar-open-note-functions~ is a list, you can also include multiple functions, to handle different note scenarios.
+
+Citar also includes a ~citar-keys-with-notes-functions~ variable, which specifies a list of functions, each of which returns a list of keys that have associated notes.
+This function allows Citar to correctly format the completion UI candidates.
+The default function only supports one-file-per-key notes.
 
 ** Files, file association and file-field parsing
 


### PR DESCRIPTION
This PR attempts to answer two questions:

1. How would we #518?
2. How, in doing so, would that include ensuring that the citar UI correctly updates the status of "has notes" display, when multiple bib notes may be contained within a single file?

So it adds a `citar-keys-with-notes-functions` defcustom, with the idea that, for example, a `citar-org-roam` package could provide a function to query the org-roam db, and provide that list of keys.

```elisp
(defun citar-org-roam--keys-with-note ()
  "Return a list of keys with associated note(s)."
  (mapcar #'car (org-roam-db-query
                 [:select ref :from refs :where (= type "cite")])))
```

And of course, that it could provide an "open-function" to have org-roam handle that.

Finally, it also, per suggestion from @roshanshariff, turns the `open-notes` variable into a list, to provide more flexibility.

Aside: this PR originally included that org-roam integration (an answer to the first question above), but I removed it to simplify. I did confirm it basically worked though, and will add a separate PR once I merge this.

-----

## Issues

I created a few little convenience functions along with this, with this unexpected result (note the first two items in the list):

```elisp
ELISP> (citar--keys-with-library-files)
("" "." "abaza2013" ...
```

I also need to figure out if this is a problem.

```elisp
ELISP> (length (citar-org-roam--keys-with-notes))
17 (#o21, #x11, ?\C-q)
ELISP> (hash-table-count (citar-file--directory-files citar-notes-paths nil citar-file-note-extensions
                                            citar-file-additional-files-separator))
33 (#o41, #x21, ?!)
```


Close #601