### PR TITLE
Strip file-paths from resource candidates

### DIFF
--- a/citar.el
+++ b/citar.el
@@ -479,7 +479,9 @@ REBUILD-CACHE and FILTER."
   "Group RESOURCE by type or TRANSFORM."
     (let ((extension (file-name-extension resource)))
       (if transform
-          resource
+          (if (file-regular-p resource)
+              (file-name-nondirectory resource)
+            resource)
         (cond
          ((member extension citar-file-note-extensions) "Notes")
          ((string-match "http" resource 0) "Links")


### PR DESCRIPTION
Maybe something to consider after 1.0.

This transforms resource candidates (notes and library files) to only filenames, removing directory paths. Much cleaner display, imo. :)

I've been using it in my fork for a while and haven't had any issues. Embark still works as expected, as the target doesn't change --- the target is still the full file path.